### PR TITLE
Add strict scope mode

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,6 +21,12 @@ final class Configuration implements ConfigurationInterface
         $rootNode->append($this->createScopesNode());
         $rootNode->append($this->createPersistenceNode());
 
+        $rootNode->children()
+            ->booleanNode('strict_scopes')
+            ->info('When set to true requests with scopes that are not defined on client or on application throw invalid scope exception. When set to false requests with no scope requested implicitly get scope from client or configuration.')
+            ->defaultTrue()
+            ->isRequired();
+
         return $treeBuilder;
     }
 

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -34,6 +34,7 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
         $this->configureAuthorizationServer($container, $config['authorization_server']);
         $this->configureResourceServer($container, $config['resource_server']);
         $this->configureScopes($container, $config['scopes']);
+        $this->configureScopeRepository($container, $config['strict_scopes']);
     }
 
     /**
@@ -177,5 +178,13 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
                 new Definition(ScopeModel::class, [$scope]),
             ]);
         }
+    }
+
+    private function configureScopeRepository(ContainerBuilder $container, bool $strictScopes)
+    {
+        $container
+            ->getDefinition('trikoder.oauth2.league.repository.scope_repository')
+            ->replaceArgument('$strictScopes', $strictScopes)
+        ;
     }
 }

--- a/Manager/InMemory/ScopeManager.php
+++ b/Manager/InMemory/ScopeManager.php
@@ -27,4 +27,9 @@ final class ScopeManager implements ScopeManagerInterface
     {
         $this->scopes[(string) $scope] = $scope;
     }
+
+    public function findAll(): array
+    {
+        return $this->scopes;
+    }
 }

--- a/Manager/ScopeManagerInterface.php
+++ b/Manager/ScopeManagerInterface.php
@@ -9,4 +9,6 @@ interface ScopeManagerInterface
     public function find(string $identifier): ?Scope;
 
     public function save(Scope $scope): void;
+
+    public function findAll(): array;
 }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ This package is currently in the active development.
                 entity_manager: default # Required
              
             in_memory: ~
+         
+        # When set to true requests with scopes that are not defined on client or on application throw invalid scope exception. 
+        # When set to false requests with no scope requested implicitly get scope from client or configuration.
+        strict_scopes: true   
+      
     ```
 
 3. Enable the bundle in `config/bundles.php` by adding it to the array:

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface" />
             <argument type="service" id="trikoder.oauth2.converter.scope_converter" />
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
+            <argument key="$strictScopes" />
         </service>
         <service id="trikoder.oauth2.league.repository.user_repository" class="Trikoder\Bundle\OAuth2Bundle\League\Repository\UserRepository">
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface" />

--- a/Tests/Acceptance/TokenEndpointTest.php
+++ b/Tests/Acceptance/TokenEndpointTest.php
@@ -16,6 +16,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             'client_id' => 'foo',
             'client_secret' => 'secret',
             'grant_type' => 'client_credentials',
+            'scope' => 'fancy',
         ]);
 
         $response = $this->client->getResponse();
@@ -28,6 +29,26 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $this->assertSame('Bearer', $jsonResponse['token_type']);
         $this->assertSame(3600, $jsonResponse['expires_in']);
         $this->assertNotEmpty($jsonResponse['access_token']);
+    }
+
+    public function testFailedClientCredentialsRequestForMissingScope()
+    {
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'client_credentials',
+        ]);
+
+        $response = $this->client->getResponse();
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+
+        $jsonResponse = json_decode($response->getContent(), true);
+
+        $this->assertSame('invalid_scope', $jsonResponse['error']);
+        $this->assertSame('The requested scope is invalid, unknown, or malformed', $jsonResponse['message']);
+        $this->assertSame('Specify a scope in the request or set a default scope', $jsonResponse['hint']);
     }
 
     public function testSuccessfulPasswordRequest()
@@ -43,6 +64,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             'client_id' => 'foo',
             'client_secret' => 'secret',
             'grant_type' => 'password',
+            'scope' => 'fancy',
             'username' => 'user',
             'password' => 'pass',
         ]);

--- a/Tests/Fixtures/FixtureFactory.php
+++ b/Tests/Fixtures/FixtureFactory.php
@@ -170,7 +170,7 @@ final class FixtureFactory
     {
         $clients = [];
 
-        $clients[] = new Client(self::FIXTURE_CLIENT_FIRST, 'secret');
+        $clients[] = (new Client(self::FIXTURE_CLIENT_FIRST, 'secret'))->setScopes(new Scope(self::FIXTURE_SCOPE_FIRST));
 
         $clients[] = new Client(self::FIXTURE_CLIENT_SECOND, 'top_secret');
 
@@ -191,6 +191,7 @@ final class FixtureFactory
         $scopes = [];
 
         $scopes[] = new Scope(self::FIXTURE_SCOPE_FIRST);
+        $scopes[] = new Scope(self::FIXTURE_SCOPE_SECOND);
 
         return $scopes;
     }

--- a/Tests/Integration/AbstractIntegrationTest.php
+++ b/Tests/Integration/AbstractIntegrationTest.php
@@ -80,7 +80,7 @@ abstract class AbstractIntegrationTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp($strictScopes = true)
     {
         $this->scopeManager = new ScopeManager();
         $this->clientManager = new ClientManager();
@@ -96,7 +96,7 @@ abstract class AbstractIntegrationTest extends TestCase
         );
 
         $scopeConverter = new ScopeConverter();
-        $scopeRepository = new ScopeRepository($this->scopeManager, $this->clientManager, $scopeConverter, $this->eventDispatcher);
+        $scopeRepository = new ScopeRepository($this->scopeManager, $this->clientManager, $scopeConverter, $this->eventDispatcher, $strictScopes);
         $clientRepository = new ClientRepository($this->clientManager);
         $accessTokenRepository = new AccessTokenRepository($this->accessTokenManager, $this->clientManager, $scopeConverter);
         $refreshTokenRepository = new RefreshTokenRepository($this->refreshTokenManager, $this->accessTokenManager);

--- a/Tests/Integration/AuthorizationServerNonStrictScopesTest.php
+++ b/Tests/Integration/AuthorizationServerNonStrictScopesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Tests\Integration;
+
+use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
+use Trikoder\Bundle\OAuth2Bundle\Tests\Fixtures\FixtureFactory;
+
+final class AuthorizationServerNonStrictScopesTest extends AbstractIntegrationTest
+{
+    protected function setUp($strictScopes = false)
+    {
+        parent::setUp($strictScopes);
+    }
+
+    public function testScopeInheritedFromClientWhenNoneRequested()
+    {
+        $request = $this->createAuthorizationRequest('foo:secret', [
+            'grant_type' => 'client_credentials',
+        ]);
+
+        $response = $this->handleAuthorizationRequest($request);
+
+        $accessToken = $this->getAccessToken($response['access_token']);
+
+        // Response assertions.
+        $this->assertSame('Bearer', $response['token_type']);
+        $this->assertSame(3600, $response['expires_in']);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
+
+        // Make sure the access token is issued for the given client ID.
+        $this->assertSame('foo', $accessToken->getClient()->getIdentifier());
+
+        // The access token should have the requested scope.
+        $this->assertEquals(
+            [
+                $this->scopeManager->find(FixtureFactory::FIXTURE_SCOPE_FIRST),
+            ],
+            $accessToken->getScopes()
+        );
+    }
+
+    public function testScopeInheritedFromConfigurationWhenNoneRequested()
+    {
+        $request = $this->createAuthorizationRequest('bar:top_secret', [
+            'grant_type' => 'client_credentials',
+        ]);
+
+        $response = $this->handleAuthorizationRequest($request);
+
+        $accessToken = $this->getAccessToken($response['access_token']);
+
+        // Response assertions.
+        $this->assertSame('Bearer', $response['token_type']);
+        $this->assertSame(3600, $response['expires_in']);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
+
+        // Make sure the access token is issued for the given client ID.
+        $this->assertSame('bar', $accessToken->getClient()->getIdentifier());
+
+        // The access token should have the requested scope.
+        $this->assertEquals(
+            [
+                $this->scopeManager->find(FixtureFactory::FIXTURE_SCOPE_FIRST),
+                $this->scopeManager->find(FixtureFactory::FIXTURE_SCOPE_SECOND),
+            ],
+            $accessToken->getScopes()
+        );
+    }
+}

--- a/Tests/Integration/AuthorizationServerNonStrictScopesTest.php
+++ b/Tests/Integration/AuthorizationServerNonStrictScopesTest.php
@@ -68,4 +68,32 @@ final class AuthorizationServerNonStrictScopesTest extends AbstractIntegrationTe
             $accessToken->getScopes()
         );
     }
+
+    public function testScopeNotChangedWhenIncludedInRequest()
+    {
+        $request = $this->createAuthorizationRequest('bar:top_secret', [
+            'grant_type' => 'client_credentials',
+            'scope' => 'rock',
+        ]);
+
+        $response = $this->handleAuthorizationRequest($request);
+
+        $accessToken = $this->getAccessToken($response['access_token']);
+
+        // Response assertions.
+        $this->assertSame('Bearer', $response['token_type']);
+        $this->assertSame(3600, $response['expires_in']);
+        $this->assertInstanceOf(AccessToken::class, $accessToken);
+
+        // Make sure the access token is issued for the given client ID.
+        $this->assertSame('bar', $accessToken->getClient()->getIdentifier());
+
+        // The access token should have the requested scope.
+        $this->assertEquals(
+            [
+                $this->scopeManager->find(FixtureFactory::FIXTURE_SCOPE_SECOND),
+            ],
+            $accessToken->getScopes()
+        );
+    }
 }

--- a/Tests/Integration/AuthorizationServerTest.php
+++ b/Tests/Integration/AuthorizationServerTest.php
@@ -14,6 +14,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
     {
         $request = $this->createAuthorizationRequest('foo:secret', [
             'grant_type' => 'client_credentials',
+            'scope' => 'fancy',
         ]);
 
         $response = $this->handleAuthorizationRequest($request);
@@ -28,6 +29,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'client_id' => 'foo',
             'client_secret' => 'secret',
             'grant_type' => 'client_credentials',
+            'scope' => 'fancy',
         ]);
 
         $response = $this->handleAuthorizationRequest($request);
@@ -135,6 +137,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
     {
         $request = $this->createAuthorizationRequest('foo:secret', [
             'grant_type' => 'client_credentials',
+            'scope' => 'fancy',
         ]);
 
         $response = $this->handleAuthorizationRequest($request);
@@ -178,6 +181,49 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
         );
     }
 
+    public function testIncorrectScopeWhenNoneRequestedAndDefinedInClient()
+    {
+        $request = $this->createAuthorizationRequest('foo:secret', [
+            'grant_type' => 'client_credentials',
+        ]);
+
+        $response = $this->handleAuthorizationRequest($request);
+
+        // Response assertions.
+        $this->assertSame('invalid_scope', $response['error']);
+        $this->assertSame('The requested scope is invalid, unknown, or malformed', $response['message']);
+        $this->assertSame('Specify a scope in the request or set a default scope', $response['hint']);
+    }
+
+    public function testIncorrectScopeWhenNoneRequestedAndDefinedInConfiguration()
+    {
+        $request = $this->createAuthorizationRequest('bar:top_secret', [
+            'grant_type' => 'client_credentials',
+        ]);
+
+        $response = $this->handleAuthorizationRequest($request);
+
+        // Response assertions.
+        $this->assertSame('invalid_scope', $response['error']);
+        $this->assertSame('The requested scope is invalid, unknown, or malformed', $response['message']);
+        $this->assertSame('Specify a scope in the request or set a default scope', $response['hint']);
+    }
+
+    public function testInvalidScopeWhenScopeDoesNotExitsOnClient(): void
+    {
+        $request = $this->createAuthorizationRequest('foo:secret', [
+            'grant_type' => 'client_credentials',
+            'scope' => 'rock',
+        ]);
+
+        $response = $this->handleAuthorizationRequest($request);
+
+        // Response assertions.
+        $this->assertSame('invalid_scope', $response['error']);
+        $this->assertSame('The requested scope is invalid, unknown, or malformed', $response['message']);
+        $this->assertSame('Check the `rock` scope', $response['hint']);
+    }
+
     public function testValidPasswordGrant(): void
     {
         $this->eventDispatcher->addListener('trikoder.oauth2.user_resolve', function (UserResolveEvent $event) {
@@ -186,6 +232,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         $request = $this->createAuthorizationRequest('foo:secret', [
             'grant_type' => 'password',
+            'scope' => 'fancy',
             'username' => 'user',
             'password' => 'pass',
         ]);

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -132,6 +132,7 @@ class TestKernel extends Kernel implements CompilerPassInterface
                     'entity_manager' => 'default',
                 ],
             ],
+            'strict_scopes' => true,
         ]);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/framework-bundle": "~4.0",
         "symfony/psr-http-message-bridge": "1.0.*",
         "symfony/security-bundle": "~4.0",
-        "zendframework/zend-diactoros": "^1.7"
+        "zendframework/zend-diactoros": "^1.7",
+        "ext-json": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.13.1",

--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -75,6 +75,11 @@ oauth2_restricted:
         oauth2_scopes: ['foo', 'bar']
 ``` 
 
+## Strict scope mode
+In default bundle operates in `strict_scopes: true` mode. In this mode scopes must be added to the token request and they must match scopes defined on the client or scopes defined in the configuration. If they don't match or no scope is included in the request invalid scope exception is thrown.
+
+When `strict_scopes` is set to `false` requests with no scope included implicitly get scope from client or configuration.
+
 ## Security roles
 
 Once the user gets past the `oauth2` firewall, they will be granted additional roles based on their granted [token scopes](controlling-token-scopes.md). The roles are named in the following format:

--- a/docs/controlling-token-scopes.md
+++ b/docs/controlling-token-scopes.md
@@ -4,8 +4,6 @@ It's possible to alter issued access token's scopes by subscribing to the `triko
 
 ## Example
 
-The following event listener will make sure the client will only be able to select scopes which they have been granted access to.
-
 ### Listener
 ```php
 <?php
@@ -22,27 +20,11 @@ final class ScopeResolveListener
     public function onScopeResolve(ScopeResolveEvent $event): void
     {
         $clientScopes = $event->getClient()->getScopes();
-
-        if (empty($clientScopes)) {
-            // If the client doesn't have any scopes defined, that means he can access everything!
-            return;
-        }
-
         $requestedScopes = $event->getScopes();
-
-        if (empty($requestedScopes)) {
-            // If the client didn't request any scopes, inherit them from the client.
-            $requestedScopes = $clientScopes;
-        }
-
-        $finalizedScopes = array_intersect($clientScopes, $requestedScopes);
-
-        if (empty($finalizedScopes)) {
-            // If the filtered scopes end up being empty, fallback to using client scopes.
-            $finalizedScopes = $clientScopes;
-        }
-
-        $event->setScopes(...$finalizedScopes);
+		
+        //Scope modification
+		
+        $event->setScopes(...$modifiedScopes);
     }
 }
 ```


### PR DESCRIPTION
Scopes missing in token request throw invalid token exception in strict mode.
In non strict mode, if scopes are missing in the request they are inherited from client or configuration #7 