### PR TITLE
Pass CryptKey instance to oauth2 with permission check disabled

### DIFF
--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -165,7 +165,11 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     {
         $container
             ->getDefinition('league.oauth2.server.resource_server')
-            ->replaceArgument('$publicKey', $config['public_key'])
+            ->replaceArgument('$publicKey', new Definition(CryptKey::class, [
+                $config['public_key'],
+                null,
+                false,
+            ]))
         ;
     }
 

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -65,7 +65,11 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     {
         $authorizationServer = $container
             ->getDefinition('league.oauth2.server.authorization_server')
-            ->replaceArgument('$privateKey', new CryptKey($config['private_key'], null, false))
+            ->replaceArgument('$privateKey', new Definition(CryptKey::class, [
+                $config['private_key'],
+                null,
+                false,
+            ]))
             ->replaceArgument('$encryptionKey', $config['encryption_key'])
         ;
 

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use League\OAuth2\Server\CryptKey;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Grant as GrantType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\RedirectUri as RedirectUriType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Scope as ScopeType;
@@ -64,7 +65,7 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     {
         $authorizationServer = $container
             ->getDefinition('league.oauth2.server.authorization_server')
-            ->replaceArgument('$privateKey', $config['private_key'])
+            ->replaceArgument('$privateKey', new CryptKey($config['private_key'], null, false))
             ->replaceArgument('$encryptionKey', $config['encryption_key'])
         ;
 

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -3,6 +3,7 @@
 namespace Trikoder\Bundle\OAuth2Bundle\DependencyInjection;
 
 use DateInterval;
+use League\OAuth2\Server\CryptKey;
 use LogicException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -12,7 +13,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use League\OAuth2\Server\CryptKey;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Grant as GrantType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\RedirectUri as RedirectUriType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Scope as ScopeType;

--- a/Tests/Integration/AbstractIntegrationTest.php
+++ b/Tests/Integration/AbstractIntegrationTest.php
@@ -5,6 +5,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Tests\Integration;
 use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Exception\CryptoException;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 use League\OAuth2\Server\Grant\PasswordGrant;
@@ -196,7 +197,7 @@ abstract class AbstractIntegrationTest extends TestCase
             $clientRepository,
             $accessTokenRepository,
             $scopeRepository,
-            TestHelper::PRIVATE_KEY_PATH,
+            new CryptKey(TestHelper::PRIVATE_KEY_PATH, null, false),
             TestHelper::ENCRYPTION_KEY
         );
 
@@ -211,7 +212,7 @@ abstract class AbstractIntegrationTest extends TestCase
     {
         return new ResourceServer(
             $accessTokenRepository,
-            TestHelper::PUBLIC_KEY_PATH
+            new CryptKey(TestHelper::PUBLIC_KEY_PATH, null, false)
         );
     }
 }

--- a/Tests/TestHelper.php
+++ b/Tests/TestHelper.php
@@ -58,7 +58,7 @@ final class TestHelper
         }
 
         return $accessTokenEntity->convertToJWT(
-            new CryptKey(self::PRIVATE_KEY_PATH)
+            new CryptKey(self::PRIVATE_KEY_PATH, null, false)
         );
     }
 

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -27,10 +27,6 @@ class TestKernel extends Kernel implements CompilerPassInterface
         putenv(sprintf('PUBLIC_KEY_PATH=%s', TestHelper::PUBLIC_KEY_PATH));
         putenv(sprintf('ENCRYPTION_KEY=%s', TestHelper::ENCRYPTION_KEY));
 
-        // The authorization server requires proper file permissions for public/private keys.
-        chmod(TestHelper::PRIVATE_KEY_PATH, 0600);
-        chmod(TestHelper::PUBLIC_KEY_PATH, 0600);
-
         parent::boot();
     }
 


### PR DESCRIPTION
Fix permission check (introduced with thephpleague/oauth2-server#776) for private keys
always failing in windows environments (also docker). Shamelessly stolen from laravel/passport#454.