### PR TITLE
Relaxed version constraint to allow v7.3 of oauth2-server 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         "php": ">=7.2",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.6",
-        "league/oauth2-server": "7.2.*",
+        "league/oauth2-server": "^7.2",
         "sensio/framework-extra-bundle": "^5.0.0",
         "symfony/framework-bundle": "~4.0",
-        "symfony/psr-http-message-bridge": "1.0.*",
+        "symfony/psr-http-message-bridge": "^1.0",
         "symfony/security-bundle": "~4.0",
         "zendframework/zend-diactoros": "^1.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         "php": ">=7.2",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.6",
-        "league/oauth2-server": "^7.2",
+        "league/oauth2-server": ">=7.2.0 <7.4.0",
         "sensio/framework-extra-bundle": "^5.0.0",
         "symfony/framework-bundle": "~4.0",
-        "symfony/psr-http-message-bridge": "^1.0",
+        "symfony/psr-http-message-bridge": "1.0.*",
         "symfony/security-bundle": "~4.0",
         "zendframework/zend-diactoros": "^1.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "league/oauth2-server": "^7.2",
         "sensio/framework-extra-bundle": "^3.0.0|^4.0.0|^5.0.0",
         "symfony/framework-bundle": "~3.4|~4.0",
-        "symfony/psr-http-message-bridge": "1.0.*",
+        "symfony/psr-http-message-bridge": "^1.0",
         "symfony/security-bundle": "~3.4|~4.0",
         "zendframework/zend-diactoros": "^1.7"
     },


### PR DESCRIPTION
v7.3.0 of oauth-server does not seem to introduce breaking changes. Call of ```finalizedScopes()``` (see ```ScopeRepository```) was moved, see https://github.com/thephpleague/oauth2-server/blob/master/CHANGELOG.md#730---released-2018-11-13