### PR TITLE
Upgrade zendframework/zend-diactoros dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/framework-bundle": "~3.4|~4.0",
         "symfony/psr-http-message-bridge": "^1.0",
         "symfony/security-bundle": "~3.4|~4.0",
-        "zendframework/zend-diactoros": "^1.7"
+        "zendframework/zend-diactoros": "^1.7|^2.1"
     },
     "require-dev": {
         "ext-timecop": "*",


### PR DESCRIPTION
Hello,

The `zendframework/zend-diactoros` dependency now has a v2.x branch supporting PSR-17.

This bundle's constraint on `zend-diactoros`'s version is `^1.7`.

It means that a user of `oauth2-bundle` can not require a version of `zend-diactoros` supporting PSR-17, which is an issue for me.

As far as I know the usage we make of `zend-diactoros` is very limited, so upgrading this dep should not have a huge impact.
Tests passed on my machine.

What do you think?

Regards,
Guillaume.