### PR TITLE
Make the enabled grant types configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -59,6 +59,18 @@ final class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                     ->defaultValue('P1M')
                 ->end()
+                ->booleanNode('enable_client_credentials_grant')
+                    ->info('Whether to enable the client credentials grant')
+                    ->defaultTrue()
+                ->end()
+                ->booleanNode('enable_password_grant')
+                    ->info('Whether to enable the password grant')
+                    ->defaultTrue()
+                ->end()
+                ->booleanNode('enable_refresh_token_grant')
+                    ->info('Whether to enable the refresh token grant')
+                    ->defaultTrue()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -143,20 +143,26 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
             ->replaceArgument('$encryptionKey', $config['encryption_key'])
         ;
 
-        $authorizationServer->addMethodCall('enableGrantType', [
-            new Reference('league.oauth2.server.grant.client_credentials_grant'),
-            new Definition(DateInterval::class, [$config['access_token_ttl']]),
-        ]);
+        if ($config['enable_client_credentials_grant']) {
+            $authorizationServer->addMethodCall('enableGrantType', [
+                new Reference('league.oauth2.server.grant.client_credentials_grant'),
+                new Definition(DateInterval::class, [$config['access_token_ttl']]),
+            ]);
+        }
 
-        $authorizationServer->addMethodCall('enableGrantType', [
-            new Reference('league.oauth2.server.grant.password_grant'),
-            new Definition(DateInterval::class, [$config['access_token_ttl']]),
-        ]);
+        if ($config['enable_password_grant']) {
+            $authorizationServer->addMethodCall('enableGrantType', [
+                new Reference('league.oauth2.server.grant.password_grant'),
+                new Definition(DateInterval::class, [$config['access_token_ttl']]),
+            ]);
+        }
 
-        $authorizationServer->addMethodCall('enableGrantType', [
-            new Reference('league.oauth2.server.grant.refresh_token_grant'),
-            new Definition(DateInterval::class, [$config['access_token_ttl']]),
-        ]);
+        if ($config['enable_refresh_token_grant']) {
+            $authorizationServer->addMethodCall('enableGrantType', [
+                new Reference('league.oauth2.server.grant.refresh_token_grant'),
+                new Definition(DateInterval::class, [$config['access_token_ttl']]),
+            ]);
+        }
 
         $this->configureGrants($container, $config);
     }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ This package is currently in the active development.
             # How long the issued refresh token should be valid for.
             # The value should be a valid interval: http://php.net/manual/en/dateinterval.construct.php#refsect1-dateinterval.construct-parameters
             refresh_token_ttl: P1M
+         
+            # Whether to enable the client credentials grant
+            enable_client_credentials_grant: true
+         
+            # Whether to enable the password grant
+            enable_password_grant: true
+         
+            # Whether to enable the refresh token grant
+            enable_refresh_token_grant: true
 
         resource_server:
 

--- a/Tests/Unit/ExtensionTest.php
+++ b/Tests/Unit/ExtensionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Trikoder\Bundle\OAuth2Bundle\DependencyInjection\TrikoderOAuth2Extension;
+use Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ScopeManager;
+use Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface;
+
+final class ExtensionTest extends TestCase
+{
+    /**
+     * @dataProvider grantsProvider
+     */
+    public function testEnablingAndDisablingGrants(string $referenceId, string $grantKey, bool $shouldTheGrantBeEnabled): void
+    {
+        $container = new ContainerBuilder();
+
+        $this->setupContainer($container);
+
+        $extension = new TrikoderOAuth2Extension();
+
+        $extension->load($this->getValidConfiguration([$grantKey => $shouldTheGrantBeEnabled]), $container);
+
+        $authorizationServer = $container->getDefinition('league.oauth2.server.authorization_server');
+        $methodCalls = $authorizationServer->getMethodCalls();
+        $isGrantEnabled = false;
+
+        foreach ($methodCalls as $methodCall) {
+            if ('enableGrantType' === $methodCall[0] && $referenceId === (string) $methodCall[1][0]) {
+                $isGrantEnabled = true;
+                break;
+            }
+        }
+
+        $this->assertSame($shouldTheGrantBeEnabled, $isGrantEnabled);
+    }
+
+    public function grantsProvider(): iterable
+    {
+        yield 'Client credentials grant can be enabled' => [
+                'league.oauth2.server.grant.client_credentials_grant', 'enable_client_credentials_grant', true,
+            ];
+        yield 'Client credentials grant can be disabled' => [
+                'league.oauth2.server.grant.client_credentials_grant', 'enable_client_credentials_grant', false,
+            ];
+        yield 'Password grant can be enabled' => [
+                'league.oauth2.server.grant.password_grant', 'enable_password_grant', true,
+            ];
+        yield 'Password grant can be disabled' => [
+                'league.oauth2.server.grant.password_grant', 'enable_password_grant', false,
+            ];
+        yield 'Refresh token grant can be enabled' => [
+                'league.oauth2.server.grant.refresh_token_grant', 'enable_refresh_token_grant', true,
+            ];
+        yield 'Refresh token grant can be disabled' => [
+                'league.oauth2.server.grant.refresh_token_grant', 'enable_refresh_token_grant', false,
+            ];
+    }
+
+    private function getValidConfiguration(array $options): array
+    {
+        return [
+            [
+                'authorization_server' => [
+                    'private_key' => 'foo',
+                    'encryption_key' => 'foo',
+                    'enable_client_credentials_grant' => $options['enable_client_credentials_grant'] ?? true,
+                    'enable_password_grant' => $options['enable_password_grant'] ?? true,
+                    'enable_refresh_token_grant' => $options['enable_refresh_token_grant'] ?? true,
+                ],
+                'resource_server' => [
+                    'public_key' => 'foo',
+                ],
+                'persistence' => [],
+            ],
+        ];
+    }
+
+    private function setupContainer(ContainerBuilder $container): void
+    {
+        $container->register(ScopeManager::class);
+        $container->setAlias(ScopeManagerInterface::class, ScopeManager::class);
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,9 @@
     </php>
 
     <testsuites>
+        <testsuite name="unit">
+            <directory>./Tests/Unit</directory>
+        </testsuite>
         <testsuite name="acceptance">
             <directory>./Tests/Acceptance</directory>
         </testsuite>


### PR DESCRIPTION
The grants are enabled by default to preserve backwards compatibility.

Closes #34 