### PR TITLE
Remove isRequired() from doctrine config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -126,7 +126,6 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('entity_manager')
                             ->info('Name of the entity manager that you wish to use for managing clients and tokens.')
-                            ->isRequired()
                             ->cannotBeEmpty()
                             ->defaultValue('default')
                         ->end()


### PR DESCRIPTION
This would allow me to write:

```yaml
trikoder_oauth2:
  persistence:
    doctrine: ~
```

If we do have `isRequired()` then there is no point in specifying a default value for `entity_manager`