### PR TITLE
Removed note about Flex

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ This package is currently in the active development.
 1. Require the bundle and a PSR 7/17 implementation with Composer:
 
     ```sh
-    composer require trikoder/oauth2-bundle nyholm/psr7 --no-plugins --no-scripts
+    composer require trikoder/oauth2-bundle nyholm/psr7
     ```
 
-    > **NOTE #1:** This bundle requires a PSR 7/17 implementation to operate. We recommend that you use [nyholm/psr7](https://github.com/Nyholm/psr7). Check out this [document](docs/psr-implementation-switching.md) if you wish to use a different implementation.
+    If your project is managed using [Symfony Flex](https://github.com/symfony/flex), the rest of the steps are not required. Just follow the post-installation instructions instead! :tada:
 
-2. Create the bundle configuration file under `config/packages/trikoder_oauth2.yaml`. Here is a reference configuration file:
+    > **NOTE:** This bundle requires a PSR 7/17 implementation to operate. We recommend that you use [nyholm/psr7](https://github.com/Nyholm/psr7). Check out this [document](docs/psr-implementation-switching.md) if you wish to use a different implementation.
+
+1. Create the bundle configuration file under `config/packages/trikoder_oauth2.yaml`. Here is a reference configuration file:
 
     ```yaml
     trikoder_oauth2:
@@ -95,19 +97,19 @@ This package is currently in the active development.
             in_memory: ~
     ```
 
-3. Enable the bundle in `config/bundles.php` by adding it to the array:
+1. Enable the bundle in `config/bundles.php` by adding it to the array:
 
     ```php
     Trikoder\Bundle\OAuth2Bundle\TrikoderOAuth2Bundle::class => ['all' => true]
     ```
 
-4. Update the database so bundle entities can be persisted using Doctrine:
+1. Update the database so bundle entities can be persisted using Doctrine:
 
     ```sh
     bin/console doctrine:schema:update --force
     ```
 
-5. Import the routes inside your `config/routes.yaml` file:
+1. Import the routes inside your `config/routes.yaml` file:
 
     ```yaml
     oauth2:

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ This package is currently in the active development.
     composer require trikoder/oauth2-bundle nyholm/psr7 --no-plugins --no-scripts
     ```
 
-    > **NOTE #1:** Due to required pre-configuration, this bundle is currently not compatible with [Symfony Flex](https://github.com/symfony/flex).
-
-    > **NOTE #2:** This bundle requires a PSR 7/17 implementation to operate. We recommend that you use [nyholm/psr7](https://github.com/Nyholm/psr7). Check out this [document](docs/psr-implementation-switching.md) if you wish to use a different implementation.
+    > **NOTE #1:** This bundle requires a PSR 7/17 implementation to operate. We recommend that you use [nyholm/psr7](https://github.com/Nyholm/psr7). Check out this [document](docs/psr-implementation-switching.md) if you wish to use a different implementation.
 
 2. Create the bundle configuration file under `config/packages/trikoder_oauth2.yaml`. Here is a reference configuration file:
 


### PR DESCRIPTION
Every package is compatible with Flex. However, you mean that you dont have a recipe. 

I think this package is an excellent candidate for a recipe. We should add something like this to a recipe to make the bundle installable: 

```
trikoder_oauth2:
  authorization_server:
    private_key: /var/oauth/private.key # Change this
    encryption_key: 'foobar' # Change this
  resource_server:
    public_key: /var/oauth/public.key # Change this
  persistence:
    doctrine: ~
```

If you submit a recipe to https://github.com/symfony/recipes-contrib I would be happy to approve it. 