### PR TITLE
Throw exceptions instead of creating responses

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -80,6 +80,10 @@ final class Configuration implements ConfigurationInterface
                     ->info('Whether to enable the authorization code grant')
                     ->defaultTrue()
                 ->end()
+                ->scalarNode('exception_event_listener_priority')
+                    ->info('The priority of the event listener that converts an Exception to a Response')
+                    ->defaultValue(10)
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,14 @@ final class Configuration implements ConfigurationInterface
         $rootNode->append($this->createScopesNode());
         $rootNode->append($this->createPersistenceNode());
 
+        $rootNode
+            ->children()
+                ->scalarNode('exception_event_listener_priority')
+                    ->info('The priority of the event listener that converts an Exception to a Response')
+                    ->defaultValue(10)
+                ->end()
+            ->end();
+
         return $treeBuilder;
     }
 
@@ -79,10 +87,6 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_auth_code_grant')
                     ->info('Whether to enable the authorization code grant')
                     ->defaultTrue()
-                ->end()
-                ->scalarNode('exception_event_listener_priority')
-                    ->info('The priority of the event listener that converts an Exception to a Response')
-                    ->defaultValue(10)
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Grant as GrantType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\RedirectUri as RedirectUriType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Scope as ScopeType;
@@ -45,6 +46,13 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
         $this->configureAuthorizationServer($container, $config['authorization_server']);
         $this->configureResourceServer($container, $config['resource_server']);
         $this->configureScopes($container, $config['scopes']);
+
+        $container->getDefinition('trikoder.oauth2.event_listener.authorization.convert_to_response')
+            ->addTag('kernel.event_listener', [
+                'event' => KernelEvents::EXCEPTION,
+                'method' => 'onKernelException',
+                'priority' => $config['exception_event_listener_priority'],
+            ]);
     }
 
     /**

--- a/EventListener/ConvertExceptionToResponseListener.php
+++ b/EventListener/ConvertExceptionToResponseListener.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\EventListener;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Trikoder\Bundle\OAuth2Bundle\Security\Exception\InsufficientScopesException;
+use Trikoder\Bundle\OAuth2Bundle\Security\Exception\Oauth2AuthenticationFailedException;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class ConvertExceptionToResponseListener
+{
+    public function onKernelException(ExceptionEvent $event)
+    {
+        $exception = $event->getException();
+        if ($exception instanceof InsufficientScopesException || $exception instanceof Oauth2AuthenticationFailedException) {
+            $event->setResponse(new Response($exception->getMessage(), $exception->getCode()));
+        }
+    }
+}

--- a/EventListener/ConvertExceptionToResponseListener.php
+++ b/EventListener/ConvertExceptionToResponseListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\EventListener;
 
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Trikoder\Bundle\OAuth2Bundle\Security\Exception\InsufficientScopesException;
 use Trikoder\Bundle\OAuth2Bundle\Security\Exception\Oauth2AuthenticationFailedException;
 
@@ -14,7 +14,7 @@ use Trikoder\Bundle\OAuth2Bundle\Security\Exception\Oauth2AuthenticationFailedEx
  */
 final class ConvertExceptionToResponseListener
 {
-    public function onKernelException(ExceptionEvent $event)
+    public function onKernelException(GetResponseForExceptionEvent $event)
     {
         $exception = $event->getException();
         if ($exception instanceof InsufficientScopesException || $exception instanceof Oauth2AuthenticationFailedException) {

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ This package is currently in the active development.
                 entity_manager: default # Required
 
             in_memory: ~
+         
+        # The priority of the event listener that converts an Exception to a Response
+        exception_event_listener_priority: 10 
+       
     ```
 
 3. Enable the bundle in `config/bundles.php` by adding it to the array:

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -92,9 +92,7 @@
             <argument type="service" id="Symfony\Component\Security\Core\Security" />
             <tag name="kernel.event_listener" event="trikoder.oauth2.authorization_request_resolve" method="onAuthorizationRequest" priority="1024" />
         </service>
-        <service id="trikoder.oauth2.event_listener.authorization.convert_to_response" class="Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener">
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="10" />
-        </service>
+        <service id="trikoder.oauth2.event_listener.authorization.convert_to_response" class="Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener" />
 
         <!-- Token controller -->
         <service id="trikoder.oauth2.controller.token_controller" class="Trikoder\Bundle\OAuth2Bundle\Controller\TokenController">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -93,7 +93,7 @@
             <tag name="kernel.event_listener" event="trikoder.oauth2.authorization_request_resolve" method="onAuthorizationRequest" priority="1024" />
         </service>
         <service id="trikoder.oauth2.event_listener.authorization.convert_to_response" class="Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener">
-            <tag name="kernel.event_listener" event="kernel.exception" method="onException" priority="-10" />
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="10" />
         </service>
 
         <!-- Token controller -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -92,6 +92,9 @@
             <argument type="service" id="Symfony\Component\Security\Core\Security" />
             <tag name="kernel.event_listener" event="trikoder.oauth2.authorization_request_resolve" method="onAuthorizationRequest" priority="1024" />
         </service>
+        <service id="trikoder.oauth2.event_listener.authorization.convert_to_response" class="Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener">
+            <tag name="kernel.event_listener" event="kernel.exception" method="onException" priority="-10" />
+        </service>
 
         <!-- Token controller -->
         <service id="trikoder.oauth2.controller.token_controller" class="Trikoder\Bundle\OAuth2Bundle\Controller\TokenController">

--- a/Security/Exception/InsufficientScopesException.php
+++ b/Security/Exception/InsufficientScopesException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Security\Exception;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class InsufficientScopesException extends AuthenticationException
+{
+    public static function create(TokenInterface $token)
+    {
+        $exception = new self('The token has insufficient scopes.', 403);
+        $exception->setToken($token);
+
+        return $exception;
+    }
+}

--- a/Security/Exception/InsufficientScopesException.php
+++ b/Security/Exception/InsufficientScopesException.php
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 class InsufficientScopesException extends AuthenticationException
 {
-    public static function create(TokenInterface $token)
+    public static function create(TokenInterface $token): self
     {
         $exception = new self('The token has insufficient scopes.', 403);
         $exception->setToken($token);

--- a/Security/Exception/Oauth2AuthenticationFailedException.php
+++ b/Security/Exception/Oauth2AuthenticationFailedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Security\Exception;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Oauth2AuthenticationFailedException extends AuthenticationException
+{
+    public static function create(string $message)
+    {
+        return new self($message, 401);
+    }
+}

--- a/Security/Exception/Oauth2AuthenticationFailedException.php
+++ b/Security/Exception/Oauth2AuthenticationFailedException.php
@@ -11,7 +11,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 class Oauth2AuthenticationFailedException extends AuthenticationException
 {
-    public static function create(string $message)
+    public static function create(string $message): self
     {
         return new self($message, 401);
     }


### PR DESCRIPTION
We should throw exceptions instead of setting a response to the `GetResponseEvent`. This will give the developer a chance to format the response. Ie to support JSON reponses. 

I've also created a listener to keep the exisiting functionality.  