### PR TITLE
Clear expired tokens command fix

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,4 +1,5 @@
 <?php
+
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 
 $finder = PhpCsFixer\Finder::create()

--- a/Command/ClearExpiredTokensCommand.php
+++ b/Command/ClearExpiredTokensCommand.php
@@ -74,7 +74,7 @@ final class ClearExpiredTokensCommand extends Command
                 'Cleared %d expired access token%s.',
                 $numOfClearedAccessTokens,
                 1 === $numOfClearedAccessTokens ? '' : 's'
-                ));
+            ));
         }
 
         if (true === $clearExpiredRefreshTokens) {

--- a/Model/RefreshToken.php
+++ b/Model/RefreshToken.php
@@ -19,7 +19,7 @@ class RefreshToken
     private $expiry;
 
     /**
-     * @var AccessToken
+     * @var AccessToken|null
      */
     private $accessToken;
 
@@ -28,7 +28,7 @@ class RefreshToken
      */
     private $revoked = false;
 
-    public function __construct(string $identifier, DateTimeInterface $expiry, AccessToken $accessToken)
+    public function __construct(string $identifier, DateTimeInterface $expiry, ?AccessToken $accessToken = null)
     {
         $this->identifier = $identifier;
         $this->expiry = $expiry;
@@ -50,7 +50,7 @@ class RefreshToken
         return $this->expiry;
     }
 
-    public function getAccessToken(): AccessToken
+    public function getAccessToken(): ?AccessToken
     {
         return $this->accessToken;
     }

--- a/Resources/config/doctrine/model/RefreshToken.orm.xml
+++ b/Resources/config/doctrine/model/RefreshToken.orm.xml
@@ -11,7 +11,7 @@
         <field name="expiry" type="datetime" />
         <field name="revoked" type="boolean" />
         <many-to-one field="accessToken" target-entity="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken">
-            <join-column name="access_token" referenced-column-name="identifier" nullable="false" />
+            <join-column name="access_token" referenced-column-name="identifier" on-delete="SET NULL" />
         </many-to-one>
     </entity>
 </doctrine-mapping>

--- a/Tests/Acceptance/AbstractAcceptanceTest.php
+++ b/Tests/Acceptance/AbstractAcceptanceTest.php
@@ -28,5 +28,11 @@ abstract class AbstractAcceptanceTest extends WebTestCase
         $this->application = new Application($this->client->getKernel());
 
         TestHelper::initializeDoctrineSchema($this->application);
+
+        $connection = $this->client->getContainer()->get('database_connection');
+        if ('sqlite' === $connection->getDatabasePlatform()->getName()) {
+            // https://www.sqlite.org/foreignkeys.html
+            $connection->executeQuery('PRAGMA foreign_keys = ON');
+        }
     }
 }

--- a/Tests/Acceptance/AuthorizationEndpointTest.php
+++ b/Tests/Acceptance/AuthorizationEndpointTest.php
@@ -43,14 +43,14 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         try {
             $this->client->request(
-            'GET',
-            '/authorize',
-            [
-                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                'response_type' => 'code',
-                'state' => 'foobar',
-            ]
-        );
+                'GET',
+                '/authorize',
+                [
+                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                    'response_type' => 'code',
+                    'state' => 'foobar',
+                ]
+            );
         } finally {
             timecop_return();
         }
@@ -81,14 +81,14 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         try {
             $this->client->request(
-            'GET',
-            '/authorize',
-            [
-                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                'response_type' => 'token',
-                'state' => 'foobar',
-            ]
-        );
+                'GET',
+                '/authorize',
+                [
+                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                    'response_type' => 'token',
+                    'state' => 'foobar',
+                ]
+            );
         } finally {
             timecop_return();
         }
@@ -122,16 +122,16 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         try {
             $this->client->request(
-            'GET',
-            '/authorize',
-            [
-                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                'response_type' => 'code',
-                'state' => 'foobar',
-                'redirect_uri' => FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI,
-                'scope' => FixtureFactory::FIXTURE_SCOPE_FIRST . ' ' . FixtureFactory::FIXTURE_SCOPE_SECOND,
-            ]
-        );
+                'GET',
+                '/authorize',
+                [
+                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                    'response_type' => 'code',
+                    'state' => 'foobar',
+                    'redirect_uri' => FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI,
+                    'scope' => FixtureFactory::FIXTURE_SCOPE_FIRST . ' ' . FixtureFactory::FIXTURE_SCOPE_SECOND,
+                ]
+            );
         } finally {
             timecop_return();
         }
@@ -160,14 +160,14 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         try {
             $this->client->request(
-            'GET',
-            '/authorize',
-            [
-                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                'response_type' => 'code',
-                'state' => 'foobar',
-            ]
-        );
+                'GET',
+                '/authorize',
+                [
+                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                    'response_type' => 'code',
+                    'state' => 'foobar',
+                ]
+            );
         } finally {
             timecop_return();
         }
@@ -196,14 +196,14 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         try {
             $this->client->request(
-            'GET',
-            '/authorize',
-            [
-                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                'response_type' => 'code',
-                'state' => 'foobar',
-            ]
-        );
+                'GET',
+                '/authorize',
+                [
+                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                    'response_type' => 'code',
+                    'state' => 'foobar',
+                ]
+            );
         } finally {
             timecop_return();
         }
@@ -234,15 +234,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         try {
             $this->client->request(
-            'GET',
-            '/authorize',
-            [
-                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                'response_type' => 'code',
-                'state' => 'foobar',
-                'redirect_uri' => 'https://example.org/oauth2/malicious-uri',
-            ]
-        );
+                'GET',
+                '/authorize',
+                [
+                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                    'response_type' => 'code',
+                    'state' => 'foobar',
+                    'redirect_uri' => 'https://example.org/oauth2/malicious-uri',
+                ]
+            );
         } finally {
             timecop_return();
         }

--- a/Tests/Acceptance/DoctrineAccessTokenManagerTest.php
+++ b/Tests/Acceptance/DoctrineAccessTokenManagerTest.php
@@ -8,6 +8,7 @@ use DateTime;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager as DoctrineAccessTokenManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
 use Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance\AbstractAcceptanceTest;
 
 /**
@@ -75,6 +76,76 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
             $client,
             null,
             []
+        );
+    }
+
+    public function testClearExpiredWithRefreshToken(): void
+    {
+        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+
+        $doctrineAccessTokenManager = new DoctrineAccessTokenManager($em);
+
+        $client = new Client('client', 'secret');
+        $em->persist($client);
+        $em->flush();
+
+        timecop_freeze(new DateTime());
+
+        try {
+            $testData = $this->buildClearExpiredTestDataWithRefreshToken($client);
+
+            /** @var RefreshToken $token */
+            foreach ($testData['input'] as $token) {
+                $doctrineAccessTokenManager->save($token->getAccessToken());
+                $em->persist($token);
+            }
+
+            $em->flush();
+
+            $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
+        } finally {
+            timecop_return();
+        }
+
+        $this->assertSame(
+            $testData['output'],
+            $em->getRepository(RefreshToken::class)->findBy(['accessToken' => null], ['identifier' => 'ASC'])
+        );
+    }
+
+    private function buildClearExpiredTestDataWithRefreshToken(Client $client): array
+    {
+        $validRefreshTokens = [
+            $this->buildRefreshToken('1111', '+1 day', $client),
+            $this->buildRefreshToken('2222', '+1 hour', $client),
+            $this->buildRefreshToken('3333', '+1 second', $client),
+            $this->buildRefreshToken('4444', 'now', $client),
+        ];
+
+        $expiredRefreshTokens = [
+            $this->buildRefreshToken('5555', '-1 day', $client),
+            $this->buildRefreshToken('6666', '-1 hour', $client),
+            $this->buildRefreshToken('7777', '-1 second', $client),
+        ];
+
+        return [
+            'input' => array_merge($validRefreshTokens, $expiredRefreshTokens),
+            'output' => $expiredRefreshTokens,
+        ];
+    }
+
+    private function buildRefreshToken(string $identifier, string $modify, Client $client): RefreshToken
+    {
+        return new RefreshToken(
+            $identifier,
+            (new DateTime('+1 day')),
+            new AccessToken(
+                $identifier,
+                (new DateTime())->modify($modify),
+                $client,
+                null,
+                []
+            )
         );
     }
 }

--- a/Tests/Acceptance/DoctrineRefreshTokenManagerTest.php
+++ b/Tests/Acceptance/DoctrineRefreshTokenManagerTest.php
@@ -37,6 +37,8 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
                 $doctrineRefreshTokenManager->save($token);
             }
 
+            $em->flush();
+
             $this->assertSame(3, $doctrineRefreshTokenManager->clearExpired());
         } finally {
             timecop_return();

--- a/Tests/Unit/ExtensionTest.php
+++ b/Tests/Unit/ExtensionTest.php
@@ -42,23 +42,23 @@ final class ExtensionTest extends TestCase
     public function grantsProvider(): iterable
     {
         yield 'Client credentials grant can be enabled' => [
-                'league.oauth2.server.grant.client_credentials_grant', 'enable_client_credentials_grant', true,
-            ];
+            'league.oauth2.server.grant.client_credentials_grant', 'enable_client_credentials_grant', true,
+        ];
         yield 'Client credentials grant can be disabled' => [
-                'league.oauth2.server.grant.client_credentials_grant', 'enable_client_credentials_grant', false,
-            ];
+            'league.oauth2.server.grant.client_credentials_grant', 'enable_client_credentials_grant', false,
+        ];
         yield 'Password grant can be enabled' => [
-                'league.oauth2.server.grant.password_grant', 'enable_password_grant', true,
-            ];
+            'league.oauth2.server.grant.password_grant', 'enable_password_grant', true,
+        ];
         yield 'Password grant can be disabled' => [
-                'league.oauth2.server.grant.password_grant', 'enable_password_grant', false,
-            ];
+            'league.oauth2.server.grant.password_grant', 'enable_password_grant', false,
+        ];
         yield 'Refresh token grant can be enabled' => [
-                'league.oauth2.server.grant.refresh_token_grant', 'enable_refresh_token_grant', true,
-            ];
+            'league.oauth2.server.grant.refresh_token_grant', 'enable_refresh_token_grant', true,
+        ];
         yield 'Refresh token grant can be disabled' => [
-                'league.oauth2.server.grant.refresh_token_grant', 'enable_refresh_token_grant', false,
-            ];
+            'league.oauth2.server.grant.refresh_token_grant', 'enable_refresh_token_grant', false,
+        ];
     }
 
     private function getValidConfiguration(array $options): array


### PR DESCRIPTION
Fixes #72 .

@spideyfusion Don't know why the `RefreshToken::$accessToken` wasn't nullable, but since `getAccessToken` is only used in some tests, making it nullable shouldn't be a problem. It makes sense since you can have a valid refresh token & an expired access token.