### PR TITLE
Remove route methods that aren't supported by the oauth2 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This package is currently in the active development.
         resource: '@TrikoderOAuth2Bundle/Resources/config/routes.xml'
     ```
 
-You can verify that everything is working by issuing a `GET` request to the `/token` endpoint.
+You can verify that everything is working by issuing a `POST` request to the `/token` endpoint.
 
 **❮ NOTE ❯** It is recommended to control the access to the authorization endpoint
 so that only logged in users can approve authorization requests.

--- a/Resources/config/routes.xml
+++ b/Resources/config/routes.xml
@@ -3,6 +3,6 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="oauth2_authorize" path="/authorize" controller="trikoder.oauth2.controller.authorization_controller:indexAction" methods="GET|POST" />
-    <route id="oauth2_token" path="/token" controller="trikoder.oauth2.controller.token_controller:indexAction" methods="GET|POST" />
+    <route id="oauth2_authorize" path="/authorize" controller="trikoder.oauth2.controller.authorization_controller:indexAction" methods="GET" />
+    <route id="oauth2_token" path="/token" controller="trikoder.oauth2.controller.token_controller:indexAction" methods="POST" />
 </routes>

--- a/Tests/Acceptance/TokenEndpointTest.php
+++ b/Tests/Acceptance/TokenEndpointTest.php
@@ -159,7 +159,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
 
     public function testFailedTokenRequest(): void
     {
-        $this->client->request('GET', '/token');
+        $this->client->request('POST', '/token');
 
         $response = $this->client->getResponse();
 


### PR DESCRIPTION
The token endpoint only supports POST while the authorize endpoint only supports GET, so the redundant methods have been removed.
Also, there was one test that was passing event though it shouldn't have.

https://github.com/thephpleague/oauth2-server/blob/86869eafbb442ed9423850ffdd1bf366c9d613e1/src/Grant/AbstractGrant.php#L534
https://github.com/thephpleague/oauth2-server/blob/86869eafbb442ed9423850ffdd1bf366c9d613e1/src/Grant/AuthCodeGrant.php#L217