### PR TITLE
Adding AuthorizationRequestResolveEventInterface

### DIFF
--- a/Controller/AuthorizationController.php
+++ b/Controller/AuthorizationController.php
@@ -11,8 +11,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Trikoder\Bundle\OAuth2Bundle\Converter\UserConverter;
-use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEvent;
 use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEventFactory;
+use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEventInterface;
 use Trikoder\Bundle\OAuth2Bundle\OAuth2Events;
 
 final class AuthorizationController
@@ -56,7 +56,7 @@ final class AuthorizationController
         try {
             $authRequest = $this->server->validateAuthorizationRequest($serverRequest);
 
-            /** @var AuthorizationRequestResolveEvent $event */
+            /** @var AuthorizationRequestResolveEventInterface $event */
             $event = $this->eventDispatcher->dispatch(
                 OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE,
                 $this->eventFactory->fromAuthorizationRequest($authRequest)

--- a/Event/AuthorizationRequestResolveEvent.php
+++ b/Event/AuthorizationRequestResolveEvent.php
@@ -13,13 +13,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
-use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
 
-final class AuthorizationRequestResolveEvent extends Event
+final class AuthorizationRequestResolveEvent extends Event implements AuthorizationRequestResolveEventInterface
 {
-    public const AUTHORIZATION_APPROVED = true;
-    public const AUTHORIZATION_DENIED = false;
-
     /**
      * @var AuthorizationRequest
      */
@@ -38,7 +34,7 @@ final class AuthorizationRequestResolveEvent extends Event
     /**
      * @var bool
      */
-    private $authorizationResolution = self::AUTHORIZATION_DENIED;
+    private $authorizationResolution = AuthorizationRequestResolveEventInterface::AUTHORIZATION_DENIED;
 
     /**
      * @var ResponseInterface|null
@@ -62,13 +58,11 @@ final class AuthorizationRequestResolveEvent extends Event
         return $this->authorizationResolution;
     }
 
-    public function resolveAuthorization(bool $authorizationResolution): self
+    public function resolveAuthorization(bool $authorizationResolution): void
     {
         $this->authorizationResolution = $authorizationResolution;
         $this->response = null;
         $this->stopPropagation();
-
-        return $this;
     }
 
     public function hasResponse(): bool
@@ -85,12 +79,10 @@ final class AuthorizationRequestResolveEvent extends Event
         return $this->response;
     }
 
-    public function setResponse(ResponseInterface $response): self
+    public function setResponse(ResponseInterface $response): void
     {
         $this->response = $response;
         $this->stopPropagation();
-
-        return $this;
     }
 
     public function getGrantTypeId(): string
@@ -115,16 +107,11 @@ final class AuthorizationRequestResolveEvent extends Event
         return $this->user;
     }
 
-    public function setUser(?UserInterface $user): self
+    public function setUser(?UserInterface $user): void
     {
         $this->user = $user;
-
-        return $this;
     }
 
-    /**
-     * @return Scope[]
-     */
     public function getScopes(): array
     {
         return $this->scopeConverter->toDomainArray(

--- a/Event/AuthorizationRequestResolveEventFactory.php
+++ b/Event/AuthorizationRequestResolveEventFactory.php
@@ -26,7 +26,7 @@ class AuthorizationRequestResolveEventFactory
         $this->clientManager = $clientManager;
     }
 
-    public function fromAuthorizationRequest(AuthorizationRequest $authorizationRequest): AuthorizationRequestResolveEvent
+    public function fromAuthorizationRequest(AuthorizationRequest $authorizationRequest): AuthorizationRequestResolveEventInterface
     {
         return new AuthorizationRequestResolveEvent($authorizationRequest, $this->scopeConverter, $this->clientManager);
     }

--- a/Event/AuthorizationRequestResolveEventInterface.php
+++ b/Event/AuthorizationRequestResolveEventInterface.php
@@ -11,7 +11,7 @@ use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
 
 /**
  * This event occurs right before the system
- * complete the authorization request.
+ * completes the authorization request.
  *
  * You could approve or deny the authorization request, or set the uri where
  * must be redirected to resolve the authorization request.

--- a/Event/AuthorizationRequestResolveEventInterface.php
+++ b/Event/AuthorizationRequestResolveEventInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Event;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+
+/**
+ * This event occurs right before the system
+ * complete the authorization request.
+ *
+ * You could approve or deny the authorization request, or set the uri where
+ * must be redirected to resolve the authorization request.
+ */
+interface AuthorizationRequestResolveEventInterface
+{
+    public const AUTHORIZATION_APPROVED = true;
+    public const AUTHORIZATION_DENIED = false;
+
+    public function getAuthorizationResolution(): bool;
+
+    public function resolveAuthorization(bool $authorizationResolution): void;
+
+    public function hasResponse(): bool;
+
+    public function getResponse(): ResponseInterface;
+
+    public function setResponse(ResponseInterface $response): void;
+
+    public function getGrantTypeId(): string;
+
+    public function getClient(): Client;
+
+    public function getUser(): ?UserInterface;
+
+    public function setUser(?UserInterface $user): void;
+
+    /**
+     * @return Scope[]
+     */
+    public function getScopes(): array;
+
+    public function isAuthorizationApproved(): bool;
+
+    public function getRedirectUri(): ?string;
+
+    public function getState(): ?string;
+
+    public function getCodeChallenge(): string;
+
+    public function getCodeChallengeMethod(): string;
+}

--- a/Event/ScopeResolveEvent.php
+++ b/Event/ScopeResolveEvent.php
@@ -9,7 +9,7 @@ use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
 
-final class ScopeResolveEvent extends Event
+final class ScopeResolveEvent extends Event implements ScopeResolveEventInterface
 {
     /**
      * @var Scope[]
@@ -39,19 +39,14 @@ final class ScopeResolveEvent extends Event
         $this->userIdentifier = $userIdentifier;
     }
 
-    /**
-     * @return Scope[]
-     */
     public function getScopes(): array
     {
         return $this->scopes;
     }
 
-    public function setScopes(Scope ...$scopes): self
+    public function setScopes(Scope ...$scopes): void
     {
         $this->scopes = $scopes;
-
-        return $this;
     }
 
     public function getGrant(): Grant

--- a/Event/ScopeResolveEventInterface.php
+++ b/Event/ScopeResolveEventInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Event;
+
+use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
+use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+
+/**
+ * This event occurs right before the user obtains their
+ * valid access token.
+ *
+ * You could alter the access token's scope here.
+ */
+interface ScopeResolveEventInterface
+{
+    /**
+     * @return Scope[]
+     */
+    public function getScopes(): array;
+
+    public function setScopes(Scope ...$scopes): void;
+
+    public function getGrant(): Grant;
+
+    public function getClient(): Client;
+
+    public function getUserIdentifier(): ?string;
+}

--- a/Event/UserResolveEvent.php
+++ b/Event/UserResolveEvent.php
@@ -9,7 +9,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
 
-final class UserResolveEvent extends Event
+final class UserResolveEvent extends Event implements UserResolveEventInterface
 {
     /**
      * @var string
@@ -69,10 +69,8 @@ final class UserResolveEvent extends Event
         return $this->user;
     }
 
-    public function setUser(?UserInterface $user): self
+    public function setUser(?UserInterface $user): void
     {
         $this->user = $user;
-
-        return $this;
     }
 }

--- a/Event/UserResolveEventInterface.php
+++ b/Event/UserResolveEventInterface.php
@@ -9,7 +9,7 @@ use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
 
 /**
- * Thi event occurs when the client requests a "password"
+ * This event occurs when the client requests a "password"
  * grant type from the authorization server.
  *
  * You should set a valid user here if applicable.

--- a/Event/UserResolveEventInterface.php
+++ b/Event/UserResolveEventInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Event;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
+
+/**
+ * Thi event occurs when the client requests a "password"
+ * grant type from the authorization server.
+ *
+ * You should set a valid user here if applicable.
+ */
+interface UserResolveEventInterface
+{
+    public function getUsername(): string;
+
+    public function getPassword(): string;
+
+    public function getGrant(): Grant;
+
+    public function getClient(): Client;
+
+    public function getUser(): ?UserInterface;
+
+    public function setUser(?UserInterface $user): void;
+}

--- a/EventListener/AuthorizationRequestUserResolvingListener.php
+++ b/EventListener/AuthorizationRequestUserResolvingListener.php
@@ -6,7 +6,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\EventListener;
 
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEvent;
+use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEventInterface;
 
 /**
  * Listener sets currently authenticated user to authorization request context
@@ -23,7 +23,7 @@ final class AuthorizationRequestUserResolvingListener
         $this->security = $security;
     }
 
-    public function onAuthorizationRequest(AuthorizationRequestResolveEvent $event): void
+    public function onAuthorizationRequest(AuthorizationRequestResolveEventInterface $event): void
     {
         $user = $this->security->getUser();
         if ($user instanceof UserInterface) {

--- a/OAuth2Events.php
+++ b/OAuth2Events.php
@@ -7,7 +7,7 @@ namespace Trikoder\Bundle\OAuth2Bundle;
 final class OAuth2Events
 {
     /**
-     * The USER_RESOLVE event occurrs when the client requests a "password"
+     * The USER_RESOLVE event occurs when the client requests a "password"
      * grant type from the authorization server.
      *
      * You should set a valid user here if applicable.
@@ -15,7 +15,7 @@ final class OAuth2Events
     public const USER_RESOLVE = 'trikoder.oauth2.user_resolve';
 
     /**
-     * The SCOPE_RESOLVE event occurrs right before the user obtains their
+     * The SCOPE_RESOLVE event occurs right before the user obtains their
      * valid access token.
      *
      * You could alter the access token's scope here.
@@ -23,7 +23,7 @@ final class OAuth2Events
     public const SCOPE_RESOLVE = 'trikoder.oauth2.scope_resolve';
 
     /**
-     * The AUTHORIZATION_REQUEST_RESOLVE event occurrs right before the system
+     * The AUTHORIZATION_REQUEST_RESOLVE event occurs right before the system
      * complete the authorization request.
      *
      * You could approve or deny the authorization request, or set the uri where

--- a/Tests/Acceptance/AuthorizationEndpointTest.php
+++ b/Tests/Acceptance/AuthorizationEndpointTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
 use DateTime;
-use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEvent;
+use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEventInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
@@ -35,8 +35,8 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
         $this->client
             ->getContainer()
             ->get('event_dispatcher')
-            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
-                $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
+            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
+                $event->resolveAuthorization(AuthorizationRequestResolveEventInterface::AUTHORIZATION_APPROVED);
             });
 
         timecop_freeze(new DateTime());
@@ -73,8 +73,8 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
         $this->client
             ->getContainer()
             ->get('event_dispatcher')
-            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
-                $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
+            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
+                $event->resolveAuthorization(AuthorizationRequestResolveEventInterface::AUTHORIZATION_APPROVED);
             });
 
         timecop_freeze(new DateTime());
@@ -113,7 +113,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
         $this->client
             ->getContainer()
             ->get('event_dispatcher')
-            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
+            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
                 $response = (new Response())->withStatus(302)->withHeader('Location', '/authorize/consent');
                 $event->setResponse($response);
             });
@@ -148,10 +148,10 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
         $eventDispatcher = $this->client
             ->getContainer()
             ->get('event_dispatcher');
-        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
-            $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
+        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
+            $event->resolveAuthorization(AuthorizationRequestResolveEventInterface::AUTHORIZATION_APPROVED);
         }, 100);
-        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
+        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
             $response = (new Response())->withStatus(302)->withHeader('Location', '/authorize/consent');
             $event->setResponse($response);
         }, 200);
@@ -184,10 +184,10 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
         $eventDispatcher = $this->client
             ->getContainer()
             ->get('event_dispatcher');
-        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
-            $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
+        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
+            $event->resolveAuthorization(AuthorizationRequestResolveEventInterface::AUTHORIZATION_APPROVED);
         }, 200);
-        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
+        $eventDispatcher->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
             $response = (new Response())->withStatus(302)->withHeader('Location', '/authorize/consent');
             $event->setResponse($response);
         }, 100);
@@ -226,8 +226,8 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
         $this->client
             ->getContainer()
             ->get('event_dispatcher')
-            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEvent $event): void {
-                $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
+            ->addListener(OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE, function (AuthorizationRequestResolveEventInterface $event): void {
+                $event->resolveAuthorization(AuthorizationRequestResolveEventInterface::AUTHORIZATION_APPROVED);
             });
 
         timecop_freeze(new DateTime());

--- a/Tests/Acceptance/TokenEndpointTest.php
+++ b/Tests/Acceptance/TokenEndpointTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
 use DateTime;
-use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
+use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEventInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
@@ -60,7 +60,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $this->client
             ->getContainer()
             ->get('event_dispatcher')
-            ->addListener('trikoder.oauth2.user_resolve', function (UserResolveEvent $event): void {
+            ->addListener('trikoder.oauth2.user_resolve', function (UserResolveEventInterface $event): void {
                 $event->setUser(FixtureFactory::createUser());
             });
 

--- a/Tests/Integration/AuthorizationServerTest.php
+++ b/Tests/Integration/AuthorizationServerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Integration;
 
 use DateTime;
-use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
+use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEventInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
 use Trikoder\Bundle\OAuth2Bundle\Tests\Fixtures\FixtureFactory;
@@ -290,7 +290,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
     public function testValidPasswordGrant(): void
     {
-        $this->eventDispatcher->addListener('trikoder.oauth2.user_resolve', function (UserResolveEvent $event): void {
+        $this->eventDispatcher->addListener('trikoder.oauth2.user_resolve', function (UserResolveEventInterface $event): void {
             $event->setUser(FixtureFactory::createUser());
         });
 
@@ -326,7 +326,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
     public function testInvalidCredentialsPasswordGrant(): void
     {
-        $this->eventDispatcher->addListener('trikoder.oauth2.user_resolve', function (UserResolveEvent $event): void {
+        $this->eventDispatcher->addListener('trikoder.oauth2.user_resolve', function (UserResolveEventInterface $event): void {
             $event->setUser(null);
         });
 

--- a/docs/controlling-token-scopes.md
+++ b/docs/controlling-token-scopes.md
@@ -10,11 +10,11 @@ It's possible to alter issued access token's scopes by subscribing to the `triko
 
 namespace App\EventListener;
 
-use Trikoder\Bundle\OAuth2Bundle\Event\ScopeResolveEvent;
+use Trikoder\Bundle\OAuth2Bundle\Event\ScopeResolveEventInterface;
 
 final class ScopeResolveListener
 {
-    public function onScopeResolve(ScopeResolveEvent $event): void
+    public function onScopeResolve(ScopeResolveEventInterface $event): void
     {
         $requestedScopes = $event->getScopes();
 

--- a/docs/password-grant-handling.md
+++ b/docs/password-grant-handling.md
@@ -17,7 +17,7 @@ namespace App\EventListener;
 
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
+use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEventInterface;
 
 final class UserResolveListener
 {
@@ -41,10 +41,7 @@ final class UserResolveListener
         $this->userPasswordEncoder = $userPasswordEncoder;
     }
 
-    /**
-     * @param UserResolveEvent $event
-     */
-    public function onUserResolve(UserResolveEvent $event): void
+    public function onUserResolve(UserResolveEventInterface $event): void
     {
         $user = $this->userProvider->loadUserByUsername($event->getUsername());
 


### PR DESCRIPTION
Related to #76 

Changes: 
- Adding an interface to our 3 events.
- Remove `return $this;`
- ~~Use `EventDispatcherInterface` from symfony contracts.~~
- Using the new syntax for `EventDispatcherInterface->dispatch()` which have the parameter swapped places. 