### PR TITLE
Make sure tests on different sf versions are wokring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,10 @@ install:
     - dev/bin/docker-compose build --build-arg PHP_VERSION=${PHP_VERSION} php
 
 before_script:
-    - dev/bin/php composer require symfony/flex --ansi --no-update
+    # Install to get dependencies. Latest version of all Symfony/* pacakges
+    - dev/bin/php composer install --ansi --prefer-dist
+    # Install symfony/flex to make sure SYMFONY_REQUIRE is working
+    - dev/bin/php composer require symfony/flex --ansi
     - dev/bin/php composer install --ansi --prefer-dist
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,28 +12,27 @@ addons:
 
 env:
     # PHP 7.2
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=3.4.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.2.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.3.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=3.4.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.2.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.3.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=3.4.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.2.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.3.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=3.4.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.2.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.3.*
 
     # PHP 7.3
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=3.4.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.2.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.3.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=3.4.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.2.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.3.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=3.4.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.2.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.3.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=3.4.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.2.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.3.*
 
 install:
     - dev/bin/docker-compose build --build-arg PHP_VERSION=${PHP_VERSION} php
 
 before_script:
     - dev/bin/php composer require symfony/flex --ansi --no-update
-    - dev/bin/php composer config extra.symfony.require "${SYMFONY_VERSION}"
-    - dev/bin/php composer install --ansi --prefer-dist --no-scripts
+    - dev/bin/php composer install --ansi --prefer-dist
 
 script:
     - dev/bin/php composer test -- --colors=always --coverage-clover=coverage.xml --debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,8 @@ install:
     - dev/bin/docker-compose build --build-arg PHP_VERSION=${PHP_VERSION} php
 
 before_script:
-    # Install to get dependencies. Latest version of all Symfony/* pacakges
-    - dev/bin/php composer update --ansi --prefer-dist
     # Install symfony/flex to make sure SYMFONY_REQUIRE is working
-    - dev/bin/php composer require symfony/flex --ansi
+    - dev/bin/php composer global require symfony/flex --ansi
     - dev/bin/php composer update --ansi --prefer-dist
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,13 @@ install:
     - dev/bin/docker-compose build --build-arg PHP_VERSION=${PHP_VERSION} php
 
 before_script:
-    # Install symfony/flex to make sure SYMFONY_VERSION is working
-    - composer global require symfony/flex --ansi
-    - composer config extra.symfony.require "${SYMFONY_VERSION}"
-    - composer update --ansi --prefer-dist
+    # Our docker image has symfony/flex installed to make sure SYMFONY_VERSION is working
+    - dev/bin/php composer config extra.symfony.require "${SYMFONY_VERSION}"
+    - dev/bin/php composer update --ansi --prefer-dist
 
 script:
-    - composer test -- --colors=always --coverage-clover=coverage.xml --debug
-    - composer lint -- --ansi --diff --dry-run --using-cache=no --verbose
+    - dev/bin/php composer test -- --colors=always --coverage-clover=coverage.xml --debug
+    - dev/bin/php composer lint -- --ansi --diff --dry-run --using-cache=no --verbose
 
 after_script:
     - dev/bin/docker-compose down --volumes

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,32 +12,33 @@ addons:
 
 env:
     # PHP 7.2
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=3.4.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.2.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.3.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=3.4.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.2.*
-    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.3.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=3.4.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.2.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.3.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=3.4.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.2.*
+    - PHP_VERSION=7.2 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.3.*
 
     # PHP 7.3
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=3.4.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.2.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_REQUIRE=4.3.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=3.4.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.2.*
-    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_REQUIRE=4.3.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=3.4.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.2.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=nyholm SYMFONY_VERSION=4.3.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=3.4.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.2.*
+    - PHP_VERSION=7.3 PSR_HTTP_PROVIDER=zendframework SYMFONY_VERSION=4.3.*
 
 install:
     - dev/bin/docker-compose build --build-arg PHP_VERSION=${PHP_VERSION} php
 
 before_script:
-    # Install symfony/flex to make sure SYMFONY_REQUIRE is working
-    - dev/bin/php composer global require symfony/flex --ansi
-    - dev/bin/php composer update --ansi --prefer-dist
+    # Install symfony/flex to make sure SYMFONY_VERSION is working
+    - composer global require symfony/flex --ansi
+    - composer config extra.symfony.require "${SYMFONY_VERSION}"
+    - composer update --ansi --prefer-dist
 
 script:
-    - dev/bin/php composer test -- --colors=always --coverage-clover=coverage.xml --debug
-    - dev/bin/php composer lint -- --ansi --diff --dry-run --using-cache=no --verbose
+    - composer test -- --colors=always --coverage-clover=coverage.xml --debug
+    - composer lint -- --ansi --diff --dry-run --using-cache=no --verbose
 
 after_script:
     - dev/bin/docker-compose down --volumes

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
 
 before_script:
     # Install to get dependencies. Latest version of all Symfony/* pacakges
-    - dev/bin/php composer install --ansi --prefer-dist
+    - dev/bin/php composer update --ansi --prefer-dist
     # Install symfony/flex to make sure SYMFONY_REQUIRE is working
     - dev/bin/php composer require symfony/flex --ansi
-    - dev/bin/php composer install --ansi --prefer-dist
+    - dev/bin/php composer update --ansi --prefer-dist
 
 script:
     - dev/bin/php composer test -- --colors=always --coverage-clover=coverage.xml --debug

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN curl --show-error https://getcomposer.org/installer | php -- \
 RUN useradd -ms /bin/sh app
 
 # Enable parallel package installation for Composer
-RUN su-exec app composer global require hirak/prestissimo
+RUN su-exec app composer global require symfony/flex
 
 COPY entrypoint.sh /usr/local/bin/docker-entrypoint
 


### PR DESCRIPTION
I made a misstake in #83.
Using `--no-scripts` will disable flex from running. In current master we are always using latest sf version. 
I wanted to run `--no-scripts` to avoid recipes being installed. That would add a bunch of new files that does not comply with our CS guidelines, ie build will always fail.

This PR first installs flex globally. Then install all packages to the correct (lower) version. That means no recipes are installed. 

~~I also use environment variable instad.~~