### PR TITLE
Add aliases for League interfaces

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface" />
         </service>
         <service id="trikoder.oauth2.league.repository.client_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ClientRepository" />
+        <service id="League\OAuth2\Server\Repositories\ClientRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ClientRepository" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\League\Repository\AccessTokenRepository">
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface" />
@@ -15,12 +16,14 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter" />
         </service>
         <service id="trikoder.oauth2.league.repository.access_token_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AccessTokenRepository" />
+        <service id="League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AccessTokenRepository" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository">
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface" />
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface" />
         </service>
         <service id="trikoder.oauth2.league.repository.refresh_token_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository" />
+        <service id="League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\League\Repository\ScopeRepository">
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface" />
@@ -29,6 +32,7 @@
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
         </service>
         <service id="trikoder.oauth2.league.repository.scope_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ScopeRepository" />
+        <service id="League\OAuth2\Server\Repositories\ScopeRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ScopeRepository" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\League\Repository\UserRepository">
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface" />
@@ -36,6 +40,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Converter\UserConverter" />
         </service>
         <service id="trikoder.oauth2.league.repository.user_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\UserRepository" />
+        <service id="League\OAuth2\Server\Repositories\UserRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\UserRepository" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository">
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface" />
@@ -43,6 +48,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter" />
         </service>
         <service id="trikoder.oauth2.league.repository.auth_code_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository" />
+        <service id="League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository" />
 
         <!-- Security layer -->
         <service id="Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Provider\OAuth2Provider">
@@ -63,9 +69,9 @@
 
         <!-- The league authorization server -->
         <service id="League\OAuth2\Server\AuthorizationServer">
-            <argument key="$clientRepository" type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\ClientRepository" />
-            <argument key="$accessTokenRepository" type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\AccessTokenRepository" />
-            <argument key="$scopeRepository" type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\ScopeRepository" />
+            <argument key="$clientRepository" type="service" id="League\OAuth2\Server\Repositories\ClientRepositoryInterface" />
+            <argument key="$accessTokenRepository" type="service" id="League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface" />
+            <argument key="$scopeRepository" type="service" id="League\OAuth2\Server\Repositories\ScopeRepositoryInterface" />
             <argument key="$privateKey" />
             <argument key="$encryptionKey" />
         </service>
@@ -73,7 +79,7 @@
 
         <!-- The league resource server -->
         <service id="League\OAuth2\Server\ResourceServer">
-            <argument key="$accessTokenRepository" type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\AccessTokenRepository" />
+            <argument key="$accessTokenRepository" type="service" id="League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface" />
             <argument key="$publicKey" />
         </service>
         <service id="league.oauth2.server.resource_server" alias="League\OAuth2\Server\ResourceServer" />
@@ -83,19 +89,19 @@
         <service id="league.oauth2.server.grant.client_credentials_grant" alias="League\OAuth2\Server\Grant\ClientCredentialsGrant" />
 
         <service id="League\OAuth2\Server\Grant\PasswordGrant">
-            <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\UserRepository" />
-            <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository" />
+            <argument type="service" id="League\OAuth2\Server\Repositories\UserRepositoryInterface" />
+            <argument type="service" id="League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface" />
         </service>
         <service id="league.oauth2.server.grant.password_grant" alias="League\OAuth2\Server\Grant\PasswordGrant" />
 
         <service id="League\OAuth2\Server\Grant\RefreshTokenGrant">
-            <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository" />
+            <argument type="service" id="League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface" />
         </service>
         <service id="league.oauth2.server.grant.refresh_token_grant" alias="League\OAuth2\Server\Grant\RefreshTokenGrant" />
 
         <service id="League\OAuth2\Server\Grant\AuthCodeGrant" >
-            <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository" />
-            <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository" />
+            <argument type="service" id="League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface" />
+            <argument type="service" id="League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface" />
             <argument key="$authCodeTTL" />
         </service>
         <service id="league.oauth2.server.grant.auth_code_grant" alias="League\OAuth2\Server\Grant\AuthCodeGrant" />


### PR DESCRIPTION
This PR adds aliases for the League interfaces so that these interfaces can be autowired. These aliases are also used now in all our other services (instead of them being hardcoded to our implementation) so that the user can easily swap the interface implementation in all services by aliasing them in their app.