### PR TITLE
Updated docs to include league/oauth2-server version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This package is currently in the active development.
 
 * [PHP 7.2](http://php.net/releases/7_2_0.php) or greater
 * [Symfony 4.2](https://symfony.com/roadmap/4.2) or [Symfony 3.4](https://symfony.com/roadmap/3.4)
+* [league/oauth2-server (versions >=7.2.0 <7.3.0)](https://packagist.org/packages/league/oauth2-server)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This package is currently in the active development.
 
 * [PHP 7.2](http://php.net/releases/7_2_0.php) or greater
 * [Symfony 4.2](https://symfony.com/roadmap/4.2) or [Symfony 3.4](https://symfony.com/roadmap/3.4)
-* [league/oauth2-server (versions >=7.2.0 <7.3.0)](https://packagist.org/packages/league/oauth2-server)
+* [league/oauth2-server (versions >=7.2.0 <8.0)](https://packagist.org/packages/league/oauth2-server)
 
 ## Installation
 


### PR DESCRIPTION
Bundle not compatible with the latest version of league/oauth2-server (v8), hence it would be good to include the requirement in the docs.