### PR TITLE
Add Composer branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,10 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
     }
 }


### PR DESCRIPTION
After we merge this in, I'll create a `v2.x` branch which we'll use as the new base branch for non-breaking changes and releases.