### PR TITLE
Lock Symfony components to 4.4.* if no other constraints are defined

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,9 @@
     "extra": {
         "branch-alias": {
             "dev-master": "3.x-dev"
+        },
+        "symfony": {
+            "require": "4.4.*"
         }
     }
 }


### PR DESCRIPTION
Fixes #132 