### PR TITLE
add Client::confidential property

### DIFF
--- a/Command/CreateClientCommand.php
+++ b/Command/CreateClientCommand.php
@@ -57,6 +57,12 @@ final class CreateClientCommand extends Command
                 'Sets allowed scope for client. Use this option multiple times to set multiple scopes.',
                 []
             )
+            ->addOption(
+                'confidential',
+                null,
+                InputOption::VALUE_NONE,
+                'Identify a client as confidential or public.'
+            )
             ->addArgument(
                 'identifier',
                 InputArgument::OPTIONAL,
@@ -93,6 +99,7 @@ final class CreateClientCommand extends Command
 
         $client = new Client($identifier, $secret);
         $client->setActive(true);
+        $client->setConfidential($input->getOption('confidential'));
 
         $redirectUris = array_map(
             function (string $redirectUri): RedirectUri { return new RedirectUri($redirectUri); },

--- a/Command/UpdateClientCommand.php
+++ b/Command/UpdateClientCommand.php
@@ -67,7 +67,7 @@ final class UpdateClientCommand extends Command
                 'confidential',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Set client confidentiality. Use this option with value 0 to set client public.',
+                'Set client confidential. If the client is confidential then the secret must be validated (PKCE client validation).',
                 true
             )
             ->addArgument(
@@ -98,10 +98,7 @@ final class UpdateClientCommand extends Command
     private function updateClientFromInput(Client $client, InputInterface $input): Client
     {
         $client->setActive(!$input->getOption('deactivated'));
-
-        if ($input->hasOption('confidential')) {
-            $client->setConfidential((bool) $input->getOption('confidential'));
-        }
+        $client->setConfidential((bool) $input->getOption('confidential'));
 
         $redirectUris = array_map(
             function (string $redirectUri): RedirectUri { return new RedirectUri($redirectUri); },

--- a/Command/UpdateClientCommand.php
+++ b/Command/UpdateClientCommand.php
@@ -63,6 +63,13 @@ final class UpdateClientCommand extends Command
                 InputOption::VALUE_NONE,
                 'If provided, it will deactivate the given client.'
             )
+            ->addOption(
+                'confidential',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Set client confidentiality. Use this option with value 0 to set client public.',
+                true
+            )
             ->addArgument(
                 'identifier',
                 InputArgument::REQUIRED,
@@ -91,6 +98,10 @@ final class UpdateClientCommand extends Command
     private function updateClientFromInput(Client $client, InputInterface $input): Client
     {
         $client->setActive(!$input->getOption('deactivated'));
+
+        if ($input->hasOption('confidential')) {
+            $client->setConfidential((bool) $input->getOption('confidential'));
+        }
 
         $redirectUris = array_map(
             function (string $redirectUri): RedirectUri { return new RedirectUri($redirectUri); },

--- a/League/Repository/ClientRepository.php
+++ b/League/Repository/ClientRepository.php
@@ -55,7 +55,7 @@ final class ClientRepository implements ClientRepositoryInterface
         }
 
         if (null === $clientSecret) {
-            return true;
+            return !$client->isConfidential();
         }
 
         if (hash_equals($client->getSecret(), (string) $clientSecret)) {

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -36,6 +36,11 @@ class Client
      */
     private $active = true;
 
+    /**
+     * @var bool
+     */
+    private $confidential = true;
+
     public function __construct(string $identifier, string $secret)
     {
         $this->identifier = $identifier;
@@ -110,6 +115,18 @@ class Client
     public function setActive(bool $active): self
     {
         $this->active = $active;
+
+        return $this;
+    }
+
+    public function isConfidential(): bool
+    {
+        return $this->confidential;
+    }
+
+    public function setConfidential(bool $confidential): self
+    {
+        $this->confidential = $confidential;
 
         return $this;
     }

--- a/Resources/config/doctrine/model/Client.orm.xml
+++ b/Resources/config/doctrine/model/Client.orm.xml
@@ -9,5 +9,6 @@
         <field name="grants" type="oauth2_grant" nullable="true" />
         <field name="scopes" type="oauth2_scope" nullable="true" />
         <field name="active" type="boolean" />
+        <field name="confidential" type="boolean" />
     </entity>
 </doctrine-mapping>

--- a/Tests/Acceptance/UpdateClientCommandTest.php
+++ b/Tests/Acceptance/UpdateClientCommandTest.php
@@ -83,6 +83,24 @@ final class UpdateClientCommandTest extends AbstractAcceptanceTest
         $this->assertFalse($updatedClient->isActive());
     }
 
+    public function testUpdateConfidential(): void
+    {
+        $client = $this->fakeAClient('bond');
+        $this->getClientManager()->save($client);
+        $this->assertTrue($client->isConfidential());
+        $command = $this->application->find('trikoder:oauth2:update-client');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'identifier' => $client->getIdentifier(),
+            '--confidential' => false,
+        ]);
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Given oAuth2 client updated successfully', $output);
+        $updatedClient = $this->getClientManager()->find($client->getIdentifier());
+        $this->assertTrue($updatedClient->isConfidential());
+    }
+
     private function fakeAClient($identifier): Client
     {
         return new Client($identifier, 'quzbaz');

--- a/Tests/Acceptance/UpdateClientCommandTest.php
+++ b/Tests/Acceptance/UpdateClientCommandTest.php
@@ -98,7 +98,7 @@ final class UpdateClientCommandTest extends AbstractAcceptanceTest
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('Given oAuth2 client updated successfully', $output);
         $updatedClient = $this->getClientManager()->find($client->getIdentifier());
-        $this->assertTrue($updatedClient->isConfidential());
+        $this->assertFalse($updatedClient->isConfidential());
     }
 
     private function fakeAClient($identifier): Client

--- a/Tests/Fixtures/FixtureFactory.php
+++ b/Tests/Fixtures/FixtureFactory.php
@@ -47,6 +47,7 @@ final class FixtureFactory
     public const FIXTURE_CLIENT_FIRST = 'foo';
     public const FIXTURE_CLIENT_SECOND = 'bar';
     public const FIXTURE_CLIENT_INACTIVE = 'baz_inactive';
+    public const FIXTURE_CLIENT_PUBLIC = 'buz_public';
     public const FIXTURE_CLIENT_RESTRICTED_GRANTS = 'qux_restricted_grants';
     public const FIXTURE_CLIENT_RESTRICTED_SCOPES = 'quux_restricted_scopes';
 
@@ -250,6 +251,9 @@ final class FixtureFactory
 
         $clients[] = (new Client(self::FIXTURE_CLIENT_INACTIVE, 'woah'))
             ->setActive(false);
+
+        $clients[] = (new Client(self::FIXTURE_CLIENT_PUBLIC, 'public'))
+            ->setConfidential(false);
 
         $clients[] = (new Client(self::FIXTURE_CLIENT_RESTRICTED_GRANTS, 'wicked'))
             ->setGrants(new Grant('password'));

--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -23,6 +23,7 @@ Options:
       --redirect-uri[=REDIRECT-URI]  Sets redirect uri for client. Use this option multiple times to set multiple redirect URIs. (multiple values allowed)
       --grant-type[=GRANT-TYPE]      Sets allowed grant type for client. Use this option multiple times to set multiple grant types. (multiple values allowed)
       --scope[=SCOPE]                Sets allowed scope for client. Use this option multiple times to set multiple scopes. (multiple values allowed)
+      --confidential                 Identify a client as confidential or public.
 ```
 
 
@@ -45,6 +46,7 @@ Options:
       --grant-type[=GRANT-TYPE]      Sets allowed grant type for client. Use this option multiple times to set multiple grant types. (multiple values allowed)
       --scope[=SCOPE]                Sets allowed scope for client. Use this option multiple times to set multiple scopes. (multiple values allowed)
       --deactivated                  If provided, it will deactivate the given client.
+      --confidential                 Set client confidentiality. Use this option with value 0 to set client public.
 ```
 
 #### Restrict which grant types a client can access


### PR DESCRIPTION
add `Client::confidential` property to fit with PKCE client validation rule:
> If the client is confidential (i.e. is capable of securely storing a secret) then the secret must be validated.

https://oauth2.thephpleague.com/client-repository-interface/#validateclient--bool