### PR TITLE
[WIP] Compatibility with Doctrine ODM (MongoDB)

### DIFF
--- a/Controller/AuthorizationController.php
+++ b/Controller/AuthorizationController.php
@@ -58,8 +58,8 @@ final class AuthorizationController
 
             /** @var AuthorizationRequestResolveEvent $event */
             $event = $this->eventDispatcher->dispatch(
-                OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE,
-                $this->eventFactory->fromAuthorizationRequest($authRequest)
+                $this->eventFactory->fromAuthorizationRequest($authRequest),
+                OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE
             );
 
             $authRequest->setUser($this->userConverter->toLeague($event->getUser()));

--- a/DBAL/Type/Grant.php
+++ b/DBAL/Type/Grant.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\TextType;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant as GrantModel;
+
+use function explode;
 
 final class Grant extends TextType
 {
@@ -27,6 +30,20 @@ final class Grant extends TextType
     public function getName()
     {
         return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        $values = explode(self::VALUE_DELIMITER, $value);
+
+        return $this->convertDatabaseValues($values);
     }
 
     /**

--- a/DBAL/Type/Grant.php
+++ b/DBAL/Type/Grant.php
@@ -6,12 +6,15 @@ namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\TextType;
+use LogicException;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant as GrantModel;
 
 use function explode;
+use function implode;
 
 final class Grant extends TextType
 {
+
     use ImplodedArray;
 
     /**
@@ -44,6 +47,26 @@ final class Grant extends TextType
         $values = explode(self::VALUE_DELIMITER, $value);
 
         return $this->convertDatabaseValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (!\is_array($value)) {
+            throw new LogicException('This type can only be used in combination with arrays.');
+        }
+
+        if (0 === \count($value)) {
+            return null;
+        }
+
+        foreach ($value as $item) {
+            $this->assertValueCanBeImploded($item);
+        }
+
+        return implode(self::VALUE_DELIMITER, $value);
     }
 
     /**

--- a/DBAL/Type/GrantOdm.php
+++ b/DBAL/Type/GrantOdm.php
@@ -21,7 +21,7 @@ final class GrantOdm extends Type
     /**
      * @var string
      */
-    private const VALUE_DELIMITER = ' ';
+    public const VALUE_DELIMITER = ' ';
 
     /**
      * {@inheritdoc}

--- a/DBAL/Type/GrantOdm.php
+++ b/DBAL/Type/GrantOdm.php
@@ -21,6 +21,19 @@ final class GrantOdm extends Type
     private const VALUE_DELIMITER = ' ';
 
     /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value)
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        $values = explode(self::VALUE_DELIMITER, $value);
+
+        return $this->convertDatabaseValues($values);
+    }
+    /**
      * @param array $values
      *
      * @return array

--- a/DBAL/Type/GrantOdm.php
+++ b/DBAL/Type/GrantOdm.php
@@ -1,14 +1,18 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
-use Doctrine\DBAL\Types\TextType;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant as GrantModel;
 
-final class Grant extends TextType
+/**
+ * Class GrantOdm
+ *
+ * @package Trikoder\Bundle\OAuth2Bundle\DBAL\Type
+ */
+final class GrantOdm extends Type
 {
+
     use ImplodedArray;
 
     /**
@@ -17,20 +21,9 @@ final class Grant extends TextType
     private const VALUE_DELIMITER = ' ';
 
     /**
-     * @var string
-     */
-    private const NAME = 'oauth2_grant';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return self::NAME;
-    }
-
-    /**
-     * {@inheritdoc}
+     * @param array $values
+     *
+     * @return array
      */
     protected function convertDatabaseValues(array $values): array
     {

--- a/DBAL/Type/GrantOdm.php
+++ b/DBAL/Type/GrantOdm.php
@@ -3,7 +3,10 @@
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\ODM\MongoDB\Types\Type;
+use LogicException;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant as GrantModel;
+
+use function implode;
 
 /**
  * Class GrantOdm
@@ -33,6 +36,27 @@ final class GrantOdm extends Type
 
         return $this->convertDatabaseValues($values);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value)
+    {
+        if (!\is_array($value)) {
+            throw new LogicException('This type can only be used in combination with arrays.');
+        }
+
+        if (0 === \count($value)) {
+            return null;
+        }
+
+        foreach ($value as $item) {
+            $this->assertValueCanBeImploded($item);
+        }
+
+        return implode(self::VALUE_DELIMITER, $value);
+    }
+
     /**
      * @param array $values
      *

--- a/DBAL/Type/GrantOdm.php
+++ b/DBAL/Type/GrantOdm.php
@@ -40,6 +40,14 @@ final class GrantOdm extends Type
     /**
      * {@inheritdoc}
      */
+    public function closureToPHP(): string
+    {
+        return '$return = explode(\Trikoder\Bundle\OAuth2Bundle\DBAL\Type\GrantOdm::VALUE_DELIMITER, $value);';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function convertToDatabaseValue($value)
     {
         if (!\is_array($value)) {

--- a/DBAL/Type/ImplodedArray.php
+++ b/DBAL/Type/ImplodedArray.php
@@ -6,30 +6,9 @@ namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use InvalidArgumentException;
-use LogicException;
 
 trait ImplodedArray
 {
-
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
-    {
-        if (!\is_array($value)) {
-            throw new LogicException('This type can only be used in combination with arrays.');
-        }
-
-        if (0 === \count($value)) {
-            return null;
-        }
-
-        foreach ($value as $item) {
-            $this->assertValueCanBeImploded($item);
-        }
-
-        return implode(self::VALUE_DELIMITER, $value);
-    }
 
     /**
      * {@inheritdoc}

--- a/DBAL/Type/ImplodedArray.php
+++ b/DBAL/Type/ImplodedArray.php
@@ -5,16 +5,11 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\TextType;
 use InvalidArgumentException;
 use LogicException;
 
-abstract class ImplodedArray extends TextType
+trait ImplodedArray
 {
-    /**
-     * @var string
-     */
-    private const VALUE_DELIMITER = ' ';
 
     /**
      * {@inheritdoc}

--- a/DBAL/Type/ImplodedArray.php
+++ b/DBAL/Type/ImplodedArray.php
@@ -34,20 +34,6 @@ trait ImplodedArray
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
-    {
-        if (null === $value) {
-            return [];
-        }
-
-        $values = explode(self::VALUE_DELIMITER, $value);
-
-        return $this->convertDatabaseValues($values);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
         $fieldDeclaration['length'] = 65535;

--- a/DBAL/Type/RedirectUri.php
+++ b/DBAL/Type/RedirectUri.php
@@ -6,9 +6,11 @@ namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\TextType;
+use LogicException;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri as RedirectUriModel;
 
 use function explode;
+use function implode;
 
 final class RedirectUri extends TextType
 {
@@ -45,6 +47,26 @@ final class RedirectUri extends TextType
         $values = explode(self::VALUE_DELIMITER, $value);
 
         return $this->convertDatabaseValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (!\is_array($value)) {
+            throw new LogicException('This type can only be used in combination with arrays.');
+        }
+
+        if (0 === \count($value)) {
+            return null;
+        }
+
+        foreach ($value as $item) {
+            $this->assertValueCanBeImploded($item);
+        }
+
+        return implode(self::VALUE_DELIMITER, $value);
     }
 
     /**

--- a/DBAL/Type/RedirectUri.php
+++ b/DBAL/Type/RedirectUri.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\TextType;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri as RedirectUriModel;
 
+use function explode;
+
 final class RedirectUri extends TextType
 {
+
     use ImplodedArray;
 
     /**
@@ -27,6 +31,20 @@ final class RedirectUri extends TextType
     public function getName()
     {
         return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        $values = explode(self::VALUE_DELIMITER, $value);
+
+        return $this->convertDatabaseValues($values);
     }
 
     /**

--- a/DBAL/Type/RedirectUri.php
+++ b/DBAL/Type/RedirectUri.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
+use Doctrine\DBAL\Types\TextType;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri as RedirectUriModel;
 
-final class RedirectUri extends ImplodedArray
+final class RedirectUri extends TextType
 {
+    use ImplodedArray;
+
+    /**
+     * @var string
+     */
+    private const VALUE_DELIMITER = ' ';
+
     /**
      * @var string
      */

--- a/DBAL/Type/RedirectUriOdm.php
+++ b/DBAL/Type/RedirectUriOdm.php
@@ -7,6 +7,8 @@ namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri as RedirectUriModel;
 
+use function explode;
+
 /**
  * Class RedirectUriOdm
  *
@@ -21,6 +23,20 @@ final class RedirectUriOdm extends Type
      * @var string
      */
     private const VALUE_DELIMITER = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value)
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        $values = explode(self::VALUE_DELIMITER, $value);
+
+        return $this->convertDatabaseValues($values);
+    }
 
     /**
      * {@inheritdoc}

--- a/DBAL/Type/RedirectUriOdm.php
+++ b/DBAL/Type/RedirectUriOdm.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
-use Doctrine\DBAL\Types\TextType;
-use Trikoder\Bundle\OAuth2Bundle\Model\Scope as ScopeModel;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri as RedirectUriModel;
 
-final class Scope extends TextType
+/**
+ * Class RedirectUriOdm
+ *
+ * @package Trikoder\Bundle\OAuth2Bundle\DBAL\Type
+ */
+final class RedirectUriOdm extends Type
 {
+
     use ImplodedArray;
 
     /**
@@ -17,25 +23,12 @@ final class Scope extends TextType
     private const VALUE_DELIMITER = ' ';
 
     /**
-     * @var string
-     */
-    private const NAME = 'oauth2_scope';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return self::NAME;
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function convertDatabaseValues(array $values): array
     {
         foreach ($values as &$value) {
-            $value = new ScopeModel($value);
+            $value = new RedirectUriModel($value);
         }
 
         return $values;

--- a/DBAL/Type/RedirectUriOdm.php
+++ b/DBAL/Type/RedirectUriOdm.php
@@ -24,7 +24,7 @@ final class RedirectUriOdm extends Type
     /**
      * @var string
      */
-    private const VALUE_DELIMITER = ' ';
+    public const VALUE_DELIMITER = ' ';
 
     /**
      * {@inheritdoc}

--- a/DBAL/Type/RedirectUriOdm.php
+++ b/DBAL/Type/RedirectUriOdm.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\ODM\MongoDB\Types\Type;
+use LogicException;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri as RedirectUriModel;
 
 use function explode;
+use function implode;
 
 /**
  * Class RedirectUriOdm
@@ -36,6 +38,26 @@ final class RedirectUriOdm extends Type
         $values = explode(self::VALUE_DELIMITER, $value);
 
         return $this->convertDatabaseValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value)
+    {
+        if (!\is_array($value)) {
+            throw new LogicException('This type can only be used in combination with arrays.');
+        }
+
+        if (0 === \count($value)) {
+            return null;
+        }
+
+        foreach ($value as $item) {
+            $this->assertValueCanBeImploded($item);
+        }
+
+        return implode(self::VALUE_DELIMITER, $value);
     }
 
     /**

--- a/DBAL/Type/RedirectUriOdm.php
+++ b/DBAL/Type/RedirectUriOdm.php
@@ -43,6 +43,14 @@ final class RedirectUriOdm extends Type
     /**
      * {@inheritdoc}
      */
+    public function closureToPHP(): string
+    {
+        return '$return = explode(\Trikoder\Bundle\OAuth2Bundle\DBAL\Type\RedirectUriOdm::VALUE_DELIMITER, $value);';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function convertToDatabaseValue($value)
     {
         if (!\is_array($value)) {

--- a/DBAL/Type/Scope.php
+++ b/DBAL/Type/Scope.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\TextType;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope as ScopeModel;
 
+use function explode;
+
 final class Scope extends TextType
 {
+
     use ImplodedArray;
 
     /**
@@ -27,6 +31,20 @@ final class Scope extends TextType
     public function getName()
     {
         return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        $values = explode(self::VALUE_DELIMITER, $value);
+
+        return $this->convertDatabaseValues($values);
     }
 
     /**

--- a/DBAL/Type/Scope.php
+++ b/DBAL/Type/Scope.php
@@ -6,9 +6,11 @@ namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\TextType;
+use LogicException;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope as ScopeModel;
 
 use function explode;
+use function implode;
 
 final class Scope extends TextType
 {
@@ -45,6 +47,26 @@ final class Scope extends TextType
         $values = explode(self::VALUE_DELIMITER, $value);
 
         return $this->convertDatabaseValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (!\is_array($value)) {
+            throw new LogicException('This type can only be used in combination with arrays.');
+        }
+
+        if (0 === \count($value)) {
+            return null;
+        }
+
+        foreach ($value as $item) {
+            $this->assertValueCanBeImploded($item);
+        }
+
+        return implode(self::VALUE_DELIMITER, $value);
     }
 
     /**

--- a/DBAL/Type/ScopeOdm.php
+++ b/DBAL/Type/ScopeOdm.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
 use Doctrine\ODM\MongoDB\Types\Type;
+use LogicException;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope as ScopeModel;
 
 use function explode;
+use function implode;
 
 /**
  * Class ScopeOdm
@@ -36,6 +38,26 @@ final class ScopeOdm extends Type
         $values = explode(self::VALUE_DELIMITER, $value);
 
         return $this->convertDatabaseValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value)
+    {
+        if (!\is_array($value)) {
+            throw new LogicException('This type can only be used in combination with arrays.');
+        }
+
+        if (0 === \count($value)) {
+            return null;
+        }
+
+        foreach ($value as $item) {
+            $this->assertValueCanBeImploded($item);
+        }
+
+        return implode(self::VALUE_DELIMITER, $value);
     }
 
     /**

--- a/DBAL/Type/ScopeOdm.php
+++ b/DBAL/Type/ScopeOdm.php
@@ -4,30 +4,23 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 
-use Doctrine\DBAL\Types\TextType;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope as ScopeModel;
 
-final class Scope extends TextType
+/**
+ * Class ScopeOdm
+ *
+ * @package Trikoder\Bundle\OAuth2Bundle\DBAL\Type
+ */
+final class ScopeOdm extends Type
 {
+
     use ImplodedArray;
 
     /**
      * @var string
      */
     private const VALUE_DELIMITER = ' ';
-
-    /**
-     * @var string
-     */
-    private const NAME = 'oauth2_scope';
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return self::NAME;
-    }
 
     /**
      * {@inheritdoc}

--- a/DBAL/Type/ScopeOdm.php
+++ b/DBAL/Type/ScopeOdm.php
@@ -24,7 +24,7 @@ final class ScopeOdm extends Type
     /**
      * @var string
      */
-    private const VALUE_DELIMITER = ' ';
+    public const VALUE_DELIMITER = ' ';
 
     /**
      * {@inheritdoc}

--- a/DBAL/Type/ScopeOdm.php
+++ b/DBAL/Type/ScopeOdm.php
@@ -43,6 +43,14 @@ final class ScopeOdm extends Type
     /**
      * {@inheritdoc}
      */
+    public function closureToPHP(): string
+    {
+        return '$return = explode(\Trikoder\Bundle\OAuth2Bundle\DBAL\Type\ScopeOdm::VALUE_DELIMITER, $value);';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function convertToDatabaseValue($value)
     {
         if (!\is_array($value)) {

--- a/DBAL/Type/ScopeOdm.php
+++ b/DBAL/Type/ScopeOdm.php
@@ -7,6 +7,8 @@ namespace Trikoder\Bundle\OAuth2Bundle\DBAL\Type;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope as ScopeModel;
 
+use function explode;
+
 /**
  * Class ScopeOdm
  *
@@ -21,6 +23,20 @@ final class ScopeOdm extends Type
      * @var string
      */
     private const VALUE_DELIMITER = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value)
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        $values = explode(self::VALUE_DELIMITER, $value);
+
+        return $this->convertDatabaseValues($values);
+    }
 
     /**
      * {@inheritdoc}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -161,6 +161,11 @@ final class Configuration implements ConfigurationInterface
                             ->cannotBeEmpty()
                             ->defaultValue('default')
                         ->end()
+                        ->scalarNode('document_manager')
+                            ->info('Name of the document manager that you wish to use for managing clients and tokens.')
+                            ->cannotBeEmpty()
+                            ->defaultValue('default')
+                        ->end()
                     ->end()
                 ->end()
                 // In-memory persistence

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -240,22 +240,22 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
 
         $container
             ->getDefinition(AccessTokenManager::class)
-            ->replaceArgument('$entityManager', $entityManager)
+            ->replaceArgument('$objectManager', $entityManager)
         ;
 
         $container
             ->getDefinition(ClientManager::class)
-            ->replaceArgument('$entityManager', $entityManager)
+            ->replaceArgument('$objectManager', $entityManager)
         ;
 
         $container
             ->getDefinition(RefreshTokenManager::class)
-            ->replaceArgument('$entityManager', $entityManager)
+            ->replaceArgument('$objectManager', $entityManager)
         ;
 
         $container
             ->getDefinition(AuthorizationCodeManager::class)
-            ->replaceArgument('$entityManager', $entityManager)
+            ->replaceArgument('$objectManager', $entityManager)
         ;
 
         $container->setParameter('trikoder.oauth2.persistence.doctrine.enabled', true);
@@ -283,7 +283,7 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     {
         $scopeManager = $container
             ->getDefinition(
-                $container->getAlias(ScopeManagerInterface::class)
+                $container->getAlias(ScopeManagerInterface::class)->__toString()
             )
         ;
 

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -241,10 +241,11 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     private function configureDoctrinePersistence(ContainerBuilder $container, array $config): void
     {
         $entityManagerName = $config['entity_manager'];
+        $documentManagerName = $config['document_manager'];
 
         $referenceId = sprintf('doctrine.orm.%s_entity_manager', $entityManagerName);
         if (class_exists(DoctrineMongoDBMappingsPass::class)) {
-            $referenceId = sprintf('doctrine_mongodb.odm.%s_document_manager', $entityManagerName);
+            $referenceId = sprintf('doctrine_mongodb.odm.%s_document_manager', $documentManagerName);
         }
 
         $entityManager = new Reference($referenceId);
@@ -270,7 +271,10 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
         ;
 
         $container->setParameter('trikoder.oauth2.persistence.doctrine.enabled', true);
-        $container->setParameter('trikoder.oauth2.persistence.doctrine.manager', $entityManagerName);
+        $container->setParameter(
+            'trikoder.oauth2.persistence.doctrine.manager',
+            class_exists(DoctrineMongoDBMappingsPass::class) ? $documentManagerName : $entityManagerName
+        );
     }
 
     private function configureInMemoryPersistence(ContainerBuilder $container): void

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -114,7 +114,7 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
             }
         }
 
-        if (!$container->hasExtension('doctrine') || !$container->hasExtension('doctrine_mongodb')) {
+        if (!$container->hasExtension('doctrine') && !$container->hasExtension('doctrine_mongodb')) {
             throw new LogicException('One of \'doctrine\' or \'doctrine_mongodb\' bundle needs to be enabled in your application kernel.');
         }
     }

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -6,6 +6,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\DependencyInjection;
 
 use DateInterval;
 use Defuse\Crypto\Key;
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
@@ -38,6 +39,9 @@ use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\RefreshTokenManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope as ScopeModel;
 use Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory;
+
+use function class_exists;
+use function sprintf;
 
 final class TrikoderOAuth2Extension extends Extension implements PrependExtensionInterface, CompilerPassInterface
 {
@@ -236,9 +240,12 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     {
         $entityManagerName = $config['entity_manager'];
 
-        $entityManager = new Reference(
-            sprintf('doctrine.orm.%s_entity_manager', $entityManagerName)
-        );
+        $referenceId = sprintf('doctrine.orm.%s_entity_manager', $entityManagerName);
+        if (class_exists(DoctrineMongoDBMappingsPass::class)) {
+            $referenceId = sprintf('doctrine_mongodb.odm.%s_document_manager', $entityManagerName);
+        }
+
+        $entityManager = new Reference($referenceId);
 
         $container
             ->getDefinition(AccessTokenManager::class)

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -84,16 +84,18 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
      */
     public function prepend(ContainerBuilder $container)
     {
-        $container->prependExtensionConfig('doctrine', [
-            'dbal' => [
-                'connections' => null,
-                'types' => [
-                    'oauth2_grant' => GrantType::class,
-                    'oauth2_redirect_uri' => RedirectUriType::class,
-                    'oauth2_scope' => ScopeType::class,
+        if ($container->hasExtension('doctrine')) {
+            $container->prependExtensionConfig('doctrine', [
+                'dbal' => [
+                    'connections' => null,
+                    'types' => [
+                        'oauth2_grant' => GrantType::class,
+                        'oauth2_redirect_uri' => RedirectUriType::class,
+                        'oauth2_scope' => ScopeType::class,
+                    ],
                 ],
-            ],
-        ]);
+            ]);
+        }
     }
 
     /**

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -6,7 +6,6 @@ namespace Trikoder\Bundle\OAuth2Bundle\DependencyInjection;
 
 use DateInterval;
 use Defuse\Crypto\Key;
-use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Grant\AuthCodeGrant;

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -104,7 +104,6 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     private function assertRequiredBundlesAreEnabled(ContainerBuilder $container): void
     {
         $requiredBundles = [
-            'doctrine' => DoctrineBundle::class,
             'security' => SecurityBundle::class,
             'sensio_framework_extra' => SensioFrameworkExtraBundle::class,
         ];
@@ -113,6 +112,10 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
             if (!$container->hasExtension($bundleAlias)) {
                 throw new LogicException(sprintf('Bundle \'%s\' needs to be enabled in your application kernel.', $requiredBundle));
             }
+        }
+
+        if (!$container->hasExtension('doctrine') || !$container->hasExtension('doctrine_mongodb')) {
+            throw new LogicException('One of \'doctrine\' or \'doctrine_mongodb\' bundle needs to be enabled in your application kernel.');
         }
     }
 

--- a/Event/AuthorizationRequestResolveEvent.php
+++ b/Event/AuthorizationRequestResolveEvent.php
@@ -7,7 +7,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Event;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use LogicException;
 use Psr\Http\Message\ResponseInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope;

--- a/Event/ScopeResolveEvent.php
+++ b/Event/ScopeResolveEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope;

--- a/Event/UserResolveEvent.php
+++ b/Event/UserResolveEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;

--- a/EventListener/ConvertExceptionToResponseListener.php
+++ b/EventListener/ConvertExceptionToResponseListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\EventListener;
 
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Trikoder\Bundle\OAuth2Bundle\Security\Exception\InsufficientScopesException;
 use Trikoder\Bundle\OAuth2Bundle\Security\Exception\Oauth2AuthenticationFailedException;
 
@@ -14,9 +14,9 @@ use Trikoder\Bundle\OAuth2Bundle\Security\Exception\Oauth2AuthenticationFailedEx
  */
 final class ConvertExceptionToResponseListener
 {
-    public function onKernelException(GetResponseForExceptionEvent $event): void
+    public function onKernelException(ExceptionEvent $event): void
     {
-        $exception = $event->getException();
+        $exception = $event->getThrowable();
         if ($exception instanceof InsufficientScopesException || $exception instanceof Oauth2AuthenticationFailedException) {
             $event->setResponse(new Response($exception->getMessage(), $exception->getCode()));
         }

--- a/League/Repository/ScopeRepository.php
+++ b/League/Repository/ScopeRepository.php
@@ -79,13 +79,13 @@ final class ScopeRepository implements ScopeRepositoryInterface
         $scopes = $this->setupScopes($client, $this->scopeConverter->toDomainArray($scopes));
 
         $event = $this->eventDispatcher->dispatch(
-            OAuth2Events::SCOPE_RESOLVE,
             new ScopeResolveEvent(
                 $scopes,
                 new GrantModel($grantType),
                 $client,
                 $userIdentifier
-            )
+            ),
+            OAuth2Events::SCOPE_RESOLVE
         );
 
         return $this->scopeConverter->toLeagueArray($event->getScopes());

--- a/League/Repository/UserRepository.php
+++ b/League/Repository/UserRepository.php
@@ -52,13 +52,13 @@ final class UserRepository implements UserRepositoryInterface
         $client = $this->clientManager->find($clientEntity->getIdentifier());
 
         $event = $this->eventDispatcher->dispatch(
-            OAuth2Events::USER_RESOLVE,
             new UserResolveEvent(
                 $username,
                 $password,
                 new GrantModel($grantType),
                 $client
-            )
+            ),
+            OAuth2Events::USER_RESOLVE
         );
 
         $user = $event->getUser();

--- a/Manager/Doctrine/AccessTokenManager.php
+++ b/Manager/Doctrine/AccessTokenManager.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
 use DateTime;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 
 final class AccessTokenManager implements AccessTokenManagerInterface
 {
     /**
-     * @var EntityManagerInterface
+     * @var ObjectManager
      */
-    private $entityManager;
+    private $objectManager;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(ObjectManager $objectManager)
     {
-        $this->entityManager = $entityManager;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -26,7 +26,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
      */
     public function find(string $identifier): ?AccessToken
     {
-        return $this->entityManager->find(AccessToken::class, $identifier);
+        return $this->objectManager->find(AccessToken::class, $identifier);
     }
 
     /**
@@ -34,13 +34,13 @@ final class AccessTokenManager implements AccessTokenManagerInterface
      */
     public function save(AccessToken $accessToken): void
     {
-        $this->entityManager->persist($accessToken);
-        $this->entityManager->flush();
+        $this->objectManager->persist($accessToken);
+        $this->objectManager->flush();
     }
 
     public function clearExpired(): int
     {
-        return $this->entityManager->createQueryBuilder()
+        return $this->objectManager->createQueryBuilder()
             ->delete(AccessToken::class, 'at')
             ->where('at.expiry < :expiry')
             ->setParameter('expiry', new DateTime())

--- a/Manager/Doctrine/AccessTokenManager.php
+++ b/Manager/Doctrine/AccessTokenManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
 use DateTime;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\ObjectManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -40,6 +41,15 @@ final class AccessTokenManager implements AccessTokenManagerInterface
 
     public function clearExpired(): int
     {
+        if ($this->objectManager instanceof DocumentManager) {
+            return $this->objectManager->createQueryBuilder()
+                ->remove(AccessToken::class)
+                ->field('expiry')->lte(new DateTime())
+                ->getQuery()
+                ->execute()
+                ->getDeletedCount();
+        }
+
         return $this->objectManager->createQueryBuilder()
             ->delete(AccessToken::class, 'at')
             ->where('at.expiry < :expiry')

--- a/Manager/Doctrine/AuthorizationCodeManager.php
+++ b/Manager/Doctrine/AuthorizationCodeManager.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
 
 final class AuthorizationCodeManager implements AuthorizationCodeManagerInterface
 {
     /**
-     * @var EntityManagerInterface
+     * @var ObjectManager
      */
-    private $entityManager;
+    private $objectManager;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(ObjectManager $objectManager)
     {
-        $this->entityManager = $entityManager;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -25,7 +25,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
      */
     public function find(string $identifier): ?AuthorizationCode
     {
-        return $this->entityManager->find(AuthorizationCode::class, $identifier);
+        return $this->objectManager->find(AuthorizationCode::class, $identifier);
     }
 
     /**
@@ -33,7 +33,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
      */
     public function save(AuthorizationCode $authorizationCode): void
     {
-        $this->entityManager->persist($authorizationCode);
-        $this->entityManager->flush();
+        $this->objectManager->persist($authorizationCode);
+        $this->objectManager->flush();
     }
 }

--- a/Manager/Doctrine/ClientManager.php
+++ b/Manager/Doctrine/ClientManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientFilter;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
@@ -12,13 +12,13 @@ use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 final class ClientManager implements ClientManagerInterface
 {
     /**
-     * @var EntityManagerInterface
+     * @var ObjectManager
      */
-    private $entityManager;
+    private $objectManager;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(ObjectManager $objectManager)
     {
-        $this->entityManager = $entityManager;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -26,7 +26,7 @@ final class ClientManager implements ClientManagerInterface
      */
     public function find(string $identifier): ?Client
     {
-        return $this->entityManager->find(Client::class, $identifier);
+        return $this->objectManager->find(Client::class, $identifier);
     }
 
     /**
@@ -34,8 +34,8 @@ final class ClientManager implements ClientManagerInterface
      */
     public function save(Client $client): void
     {
-        $this->entityManager->persist($client);
-        $this->entityManager->flush();
+        $this->objectManager->persist($client);
+        $this->objectManager->flush();
     }
 
     /**
@@ -43,8 +43,8 @@ final class ClientManager implements ClientManagerInterface
      */
     public function remove(Client $client): void
     {
-        $this->entityManager->remove($client);
-        $this->entityManager->flush();
+        $this->objectManager->remove($client);
+        $this->objectManager->flush();
     }
 
     /**
@@ -52,7 +52,7 @@ final class ClientManager implements ClientManagerInterface
      */
     public function list(?ClientFilter $clientFilter): array
     {
-        $repository = $this->entityManager->getRepository(Client::class);
+        $repository = $this->objectManager->getRepository(Client::class);
         $criteria = self::filterToCriteria($clientFilter);
 
         return $repository->findBy($criteria);

--- a/Manager/Doctrine/RefreshTokenManager.php
+++ b/Manager/Doctrine/RefreshTokenManager.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
 use DateTime;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
 
 final class RefreshTokenManager implements RefreshTokenManagerInterface
 {
     /**
-     * @var EntityManagerInterface
+     * @var ObjectManager
      */
-    private $entityManager;
+    private $objectManager;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(ObjectManager $objectManager)
     {
-        $this->entityManager = $entityManager;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -26,7 +26,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
      */
     public function find(string $identifier): ?RefreshToken
     {
-        return $this->entityManager->find(RefreshToken::class, $identifier);
+        return $this->objectManager->find(RefreshToken::class, $identifier);
     }
 
     /**
@@ -34,13 +34,13 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
      */
     public function save(RefreshToken $refreshToken): void
     {
-        $this->entityManager->persist($refreshToken);
-        $this->entityManager->flush();
+        $this->objectManager->persist($refreshToken);
+        $this->objectManager->flush();
     }
 
     public function clearExpired(): int
     {
-        return $this->entityManager->createQueryBuilder()
+        return $this->objectManager->createQueryBuilder()
             ->delete(RefreshToken::class, 'rt')
             ->where('rt.expiry < :expiry')
             ->setParameter('expiry', new DateTime())

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ This package is currently in the active development.
 
                 # Name of the entity manager that you wish to use for managing clients and tokens.
                 entity_manager:       default
+
+                # Name of the document manager that you wish to use for managing clients and tokens.
+                document_manager:       default
             in_memory:            ~
 
         # The priority of the event listener that converts an Exception to a Response
@@ -119,11 +122,17 @@ This package is currently in the active development.
     Trikoder\Bundle\OAuth2Bundle\TrikoderOAuth2Bundle::class => ['all' => true]
     ```
 
-1. Update the database so bundle entities can be persisted using Doctrine:
+1. Update the database so bundle models can be persisted using Doctrine:
 
     ```sh
     bin/console doctrine:schema:update --force
     ```
+   > For Doctrine ORM (entities)
+
+    ```sh
+    bin/console doctrine:mongodb:schema:update
+   ```
+   > For Doctrine ODM (documents)
 
 1. Import the routes inside your `config/routes.yaml` file:
 

--- a/Resources/config/doctrine/model/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/model/AccessToken.mongodb.xml
@@ -1,0 +1,13 @@
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                            http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken">
+        <id />
+        <field field-name="expiry" type="date" />
+        <field field-name="userIdentifier" type="string" nullable="true" />
+        <field field-name="scopes" type="oauth2_scope" nullable="true" />
+        <field field-name="revoked" type="boolean" />
+        <reference-one field="client" target-document="Trikoder\Bundle\OAuth2Bundle\Model\Client" />
+    </document>
+</doctrine-mongo-mapping>

--- a/Resources/config/doctrine/model/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/model/AccessToken.mongodb.xml
@@ -3,7 +3,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken">
-        <id field-name="identifier" />
+        <id field-name="identifier" strategy="NONE" />
         <field field-name="expiry" type="date" />
         <field field-name="userIdentifier" type="string" nullable="true" />
         <field field-name="scopes" type="oauth2_scope" nullable="true" />

--- a/Resources/config/doctrine/model/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/model/AccessToken.mongodb.xml
@@ -3,7 +3,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken">
-        <id />
+        <id field-name="identifier" />
         <field field-name="expiry" type="date" />
         <field field-name="userIdentifier" type="string" nullable="true" />
         <field field-name="scopes" type="oauth2_scope" nullable="true" />

--- a/Resources/config/doctrine/model/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/model/AccessToken.mongodb.xml
@@ -2,7 +2,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <document name="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken" collection="OAuth2AccessToken">
         <id field-name="identifier" strategy="NONE" />
         <field field-name="expiry" type="date" />
         <field field-name="userIdentifier" type="string" nullable="true" />

--- a/Resources/config/doctrine/model/AuthorizationCode.mongodb.xml
+++ b/Resources/config/doctrine/model/AuthorizationCode.mongodb.xml
@@ -1,0 +1,13 @@
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                            http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode">
+        <id />
+        <field field-name="expiry" type="date" />
+        <field field-name="userIdentifier" type="string" nullable="true" />
+        <field field-name="scopes" type="oauth2_scope" nullable="true" />
+        <field field-name="revoked" type="boolean" />
+        <reference-one field="client" target-document="Trikoder\Bundle\OAuth2Bundle\Model\Client" />
+    </document>
+</doctrine-mongo-mapping>

--- a/Resources/config/doctrine/model/AuthorizationCode.mongodb.xml
+++ b/Resources/config/doctrine/model/AuthorizationCode.mongodb.xml
@@ -3,7 +3,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode">
-        <id />
+        <id field-name="identifier" />
         <field field-name="expiry" type="date" />
         <field field-name="userIdentifier" type="string" nullable="true" />
         <field field-name="scopes" type="oauth2_scope" nullable="true" />

--- a/Resources/config/doctrine/model/AuthorizationCode.mongodb.xml
+++ b/Resources/config/doctrine/model/AuthorizationCode.mongodb.xml
@@ -2,7 +2,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <document name="Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode" collection="OAuth2AuthorizationCode">
         <id field-name="identifier" />
         <field field-name="expiry" type="date" />
         <field field-name="userIdentifier" type="string" nullable="true" />

--- a/Resources/config/doctrine/model/Client.mongodb.xml
+++ b/Resources/config/doctrine/model/Client.mongodb.xml
@@ -1,0 +1,13 @@
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                            http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\Client">
+        <id />
+        <field field-name="secret" type="string" />
+        <field field-name="redirectUris" type="oauth2_redirect_uri" nullable="true" />
+        <field field-name="grants" type="oauth2_grant" nullable="true" />
+        <field field-name="scopes" type="oauth2_scope" nullable="true" />
+        <field field-name="active" type="boolean" />
+    </document>
+</doctrine-mongo-mapping>

--- a/Resources/config/doctrine/model/Client.mongodb.xml
+++ b/Resources/config/doctrine/model/Client.mongodb.xml
@@ -3,7 +3,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\Client">
-        <id field-name="identifier" />
+        <id field-name="identifier" strategy="NONE" />
         <field field-name="secret" type="string" />
         <field field-name="redirectUris" type="oauth2_redirect_uri" nullable="true" />
         <field field-name="grants" type="oauth2_grant" nullable="true" />

--- a/Resources/config/doctrine/model/Client.mongodb.xml
+++ b/Resources/config/doctrine/model/Client.mongodb.xml
@@ -2,7 +2,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <document name="Trikoder\Bundle\OAuth2Bundle\Model\Client">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\Client" collection="OAuth2Client">
         <id field-name="identifier" strategy="NONE" />
         <field field-name="secret" type="string" />
         <field field-name="redirectUris" type="oauth2_redirect_uri" />

--- a/Resources/config/doctrine/model/Client.mongodb.xml
+++ b/Resources/config/doctrine/model/Client.mongodb.xml
@@ -5,9 +5,9 @@
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\Client">
         <id field-name="identifier" strategy="NONE" />
         <field field-name="secret" type="string" />
-        <field field-name="redirectUris" type="oauth2_redirect_uri" nullable="true" />
-        <field field-name="grants" type="oauth2_grant" nullable="true" />
-        <field field-name="scopes" type="oauth2_scope" nullable="true" />
+        <field field-name="redirectUris" type="oauth2_redirect_uri" />
+        <field field-name="grants" type="oauth2_grant" />
+        <field field-name="scopes" type="oauth2_scope" />
         <field field-name="active" type="boolean" />
     </document>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/model/Client.mongodb.xml
+++ b/Resources/config/doctrine/model/Client.mongodb.xml
@@ -3,7 +3,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\Client">
-        <id />
+        <id field-name="identifier" />
         <field field-name="secret" type="string" />
         <field field-name="redirectUris" type="oauth2_redirect_uri" nullable="true" />
         <field field-name="grants" type="oauth2_grant" nullable="true" />

--- a/Resources/config/doctrine/model/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/model/RefreshToken.mongodb.xml
@@ -2,7 +2,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <document name="Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken" collection="OAuth2RefreshToken">
         <id field-name="identifier" strategy="NONE" />
         <field field-name="expiry" type="date" />
         <field field-name="revoked" type="boolean" />

--- a/Resources/config/doctrine/model/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/model/RefreshToken.mongodb.xml
@@ -3,7 +3,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken">
-        <id />
+        <id field-name="identifier" />
         <field field-name="expiry" type="datetime" />
         <field field-name="revoked" type="boolean" />
         <reference-one field="accessToken" target-document="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken" />

--- a/Resources/config/doctrine/model/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/model/RefreshToken.mongodb.xml
@@ -1,0 +1,11 @@
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                            http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+    <document name="Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken">
+        <id />
+        <field field-name="expiry" type="datetime" />
+        <field field-name="revoked" type="boolean" />
+        <reference-one field="accessToken" target-document="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken" />
+    </document>
+</doctrine-mongo-mapping>

--- a/Resources/config/doctrine/model/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/model/RefreshToken.mongodb.xml
@@ -3,8 +3,8 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                             http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <document name="Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken">
-        <id field-name="identifier" />
-        <field field-name="expiry" type="datetime" />
+        <id field-name="identifier" strategy="NONE" />
+        <field field-name="expiry" type="date" />
         <field field-name="revoked" type="boolean" />
         <reference-one field="accessToken" target-document="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken" />
     </document>

--- a/Resources/config/storage/doctrine.xml
+++ b/Resources/config/storage/doctrine.xml
@@ -11,17 +11,17 @@
 
         <!-- Services -->
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager">
-            <argument key="$entityManager" />
+            <argument key="$objectManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.client_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager">
-            <argument key="$entityManager" />
+            <argument key="$objectManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.access_token_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\RefreshTokenManager">
-            <argument key="$entityManager" />
+            <argument key="$objectManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.refresh_token_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\RefreshTokenManager" />
 
@@ -29,7 +29,7 @@
         <service id="trikoder.oauth2.manager.in_memory.scope_manager" class="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ScopeManager" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AuthorizationCodeManager">
-            <argument key="$entityManager" />
+            <argument key="$objectManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.authorization_code_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AuthorizationCodeManager" />
     </services>

--- a/Security/Firewall/OAuth2Listener.php
+++ b/Security/Firewall/OAuth2Listener.php
@@ -6,17 +6,16 @@ namespace Trikoder\Bundle\OAuth2Bundle\Security\Firewall;
 
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2Token;
 use Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory;
 use Trikoder\Bundle\OAuth2Bundle\Security\Exception\InsufficientScopesException;
 use Trikoder\Bundle\OAuth2Bundle\Security\Exception\Oauth2AuthenticationFailedException;
 
-final class OAuth2Listener implements ListenerInterface
+final class OAuth2Listener
 {
     /**
      * @var TokenStorageInterface
@@ -50,15 +49,7 @@ final class OAuth2Listener implements ListenerInterface
         $this->oauth2TokenFactory = $oauth2TokenFactory;
     }
 
-    /**
-     * BC layer for Symfony < 4.3
-     */
-    public function handle(GetResponseEvent $event)
-    {
-        $this->__invoke($event);
-    }
-
-    public function __invoke(GetResponseEvent $event)
+    public function __invoke(ResponseEvent $event)
     {
         $request = $this->httpMessageFactory->createRequest($event->getRequest());
 

--- a/Security/Firewall/OAuth2Listener.php
+++ b/Security/Firewall/OAuth2Listener.php
@@ -6,7 +6,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Security\Firewall;
 
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -49,7 +49,7 @@ final class OAuth2Listener
         $this->oauth2TokenFactory = $oauth2TokenFactory;
     }
 
-    public function __invoke(ResponseEvent $event)
+    public function __invoke(RequestEvent $event)
     {
         $request = $this->httpMessageFactory->createRequest($event->getRequest());
 

--- a/Tests/Acceptance/DoctrineClientManagerTest.php
+++ b/Tests/Acceptance/DoctrineClientManagerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
 use DateTime;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager as DoctrineClientManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
@@ -19,18 +19,18 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
 {
     public function testSimpleDelete(): void
     {
-        /** @var $em EntityManagerInterface */
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
-        $doctrineClientManager = new DoctrineClientManager($em);
+        /** @var $objectManager ObjectManager */
+        $objectManager = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $doctrineClientManager = new DoctrineClientManager($objectManager);
 
         $client = new Client('client', 'secret');
-        $em->persist($client);
-        $em->flush();
+        $objectManager->persist($client);
+        $objectManager->flush();
 
         $doctrineClientManager->remove($client);
 
         $this->assertNull(
-            $em
+            $objectManager
                 ->getRepository(Client::class)
                 ->find($client->getIdentifier())
         );
@@ -38,32 +38,32 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
 
     public function testClientDeleteCascadesToAccessTokens(): void
     {
-        /** @var $em EntityManagerInterface */
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
-        $doctrineClientManager = new DoctrineClientManager($em);
+        /** @var $objectManager ObjectManager */
+        $objectManager = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $doctrineClientManager = new DoctrineClientManager($objectManager);
 
         $client = new Client('client', 'secret');
-        $em->persist($client);
-        $em->flush();
+        $objectManager->persist($client);
+        $objectManager->flush();
 
         $accessToken = new AccessToken('access token', (new DateTime())->modify('+1 day'), $client, $client->getIdentifier(), []);
-        $em->persist($accessToken);
-        $em->flush();
+        $objectManager->persist($accessToken);
+        $objectManager->flush();
 
         $doctrineClientManager->remove($client);
 
         $this->assertNull(
-            $em
+            $objectManager
                 ->getRepository(Client::class)
                 ->find($client->getIdentifier())
         );
 
         // The entity manager has to be cleared manually
         // because it doesn't process deep integrity constraints
-        $em->clear();
+        $objectManager->clear();
 
         $this->assertNull(
-            $em
+            $objectManager
                 ->getRepository(AccessToken::class)
                 ->find($accessToken->getIdentifier())
         );
@@ -71,42 +71,42 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
 
     public function testClientDeleteCascadesToAccessTokensAndRefreshTokens(): void
     {
-        /** @var $em EntityManagerInterface */
-        $em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
-        $doctrineClientManager = new DoctrineClientManager($em);
+        /** @var $objectManager ObjectManager */
+        $objectManager = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $doctrineClientManager = new DoctrineClientManager($objectManager);
 
         $client = new Client('client', 'secret');
-        $em->persist($client);
-        $em->flush();
+        $objectManager->persist($client);
+        $objectManager->flush();
 
         $accessToken = new AccessToken('access token', (new DateTime())->modify('+1 day'), $client, $client->getIdentifier(), []);
-        $em->persist($accessToken);
-        $em->flush();
+        $objectManager->persist($accessToken);
+        $objectManager->flush();
 
         $refreshToken = new RefreshToken('refresh token', (new DateTime())->modify('+1 day'), $accessToken);
-        $em->persist($refreshToken);
-        $em->flush();
+        $objectManager->persist($refreshToken);
+        $objectManager->flush();
 
         $doctrineClientManager->remove($client);
 
         $this->assertNull(
-            $em
+            $objectManager
                 ->getRepository(Client::class)
                 ->find($client->getIdentifier())
         );
 
         // The entity manager has to be cleared manually
         // because it doesn't process deep integrity constraints
-        $em->clear();
+        $objectManager->clear();
 
         $this->assertNull(
-            $em
+            $objectManager
                 ->getRepository(AccessToken::class)
                 ->find($accessToken->getIdentifier())
         );
 
         /** @var $refreshToken RefreshToken */
-        $refreshToken = $em
+        $refreshToken = $objectManager
             ->getRepository(RefreshToken::class)
             ->find($refreshToken->getIdentifier())
         ;

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -138,6 +138,19 @@ final class TestKernel extends Kernel implements CompilerPassInterface
             'orm' => null,
         ]);
 
+        $container->loadFromExtension('doctrine_mongodb', [
+            'connections' => [
+                'default' => [
+                    'server' => 'mongodb://test:test@db:27017'
+                ],
+            ],
+            'document_managers' => [
+                'default' => [
+                    'auto_mapping' => true,
+                ],
+            ],
+        ]);
+
         $container->loadFromExtension('framework', [
             'secret' => 'nope',
             'test' => null,

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -57,6 +57,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
     {
         return [
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
@@ -183,6 +184,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
             'persistence' => [
                 'doctrine' => [
                     'entity_manager' => 'default',
+                    'document_manager' => 'default',
                 ],
             ],
         ]);

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -141,7 +141,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
         $container->loadFromExtension('doctrine_mongodb', [
             'connections' => [
                 'default' => [
-                    'server' => 'mongodb://test:test@db:27017'
+                    'server' => 'mongodb://test:test@mongo:27017'
                 ],
             ],
             'document_managers' => [

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -199,6 +199,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                 $container
                     ->getAlias(ScopeManagerInterface::class)
                     ->setPublic(true)
+                    ->__toString()
             )
             ->setPublic(true)
         ;
@@ -208,6 +209,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                 $container
                     ->getAlias(ClientManagerInterface::class)
                     ->setPublic(true)
+                    ->__toString()
             )
             ->setPublic(true)
         ;
@@ -217,6 +219,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                 $container
                     ->getAlias(AccessTokenManagerInterface::class)
                     ->setPublic(true)
+                    ->__toString()
             )
             ->setPublic(true)
         ;
@@ -226,6 +229,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                 $container
                     ->getAlias(RefreshTokenManagerInterface::class)
                     ->setPublic(true)
+                    ->__toString()
             )
             ->setPublic(true)
         ;
@@ -235,6 +239,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
                 $container
                     ->getAlias(AuthorizationCodeManagerInterface::class)
                     ->setPublic(true)
+                    ->__toString()
             )
             ->setPublic(true)
         ;

--- a/TrikoderOAuth2Bundle.php
+++ b/TrikoderOAuth2Bundle.php
@@ -6,7 +6,6 @@ namespace Trikoder\Bundle\OAuth2Bundle;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
-use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,22 +20,14 @@ final class TrikoderOAuth2Bundle extends Bundle
 {
 
     /**
-     * {@inheritdoc}
-     * @throws MappingException
+     * TrikoderOAuth2Bundle constructor.
      */
-    public function boot()
+    public function __construct()
     {
-        parent::boot();
         if (class_exists(DoctrineMongoDBMappingsPass::class)) {
-            if (!Type::hasType('oauth2_grant')) {
-                Type::addType('oauth2_grant', GrantOdm::class);
-            }
-            if (!Type::hasType('oauth2_redirect_uri')) {
-                Type::addType('oauth2_redirect_uri', RedirectUriOdm::class);
-            }
-            if (!Type::hasType('oauth2_scope')) {
-                Type::addType('oauth2_scope', ScopeOdm::class);
-            }
+            Type::registerType('oauth2_grant', GrantOdm::class);
+            Type::registerType('oauth2_redirect_uri', RedirectUriOdm::class);
+            Type::registerType('oauth2_scope', ScopeOdm::class);
         }
     }
 

--- a/TrikoderOAuth2Bundle.php
+++ b/TrikoderOAuth2Bundle.php
@@ -24,15 +24,30 @@ final class TrikoderOAuth2Bundle extends Bundle
      * {@inheritdoc}
      * @throws MappingException
      */
+    public function boot()
+    {
+        parent::boot();
+        if (class_exists(DoctrineMongoDBMappingsPass::class)) {
+            if (!Type::hasType('oauth2_grant')) {
+                Type::addType('oauth2_grant', GrantOdm::class);
+            }
+            if (!Type::hasType('oauth2_redirect_uri')) {
+                Type::addType('oauth2_redirect_uri', RedirectUriOdm::class);
+            }
+            if (!Type::hasType('oauth2_scope')) {
+                Type::addType('oauth2_scope', ScopeOdm::class);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
 
         if (class_exists(DoctrineMongoDBMappingsPass::class)) {
-            Type::addType('oauth2_grant', GrantOdm::class);
-            Type::addType('oauth2_redirect_uri', RedirectUriOdm::class);
-            Type::addType('oauth2_scope', ScopeOdm::class);
-
             $this->configureDoctrineMongoExtension($container);
         } else {
             $this->configureDoctrineOrmExtension($container);

--- a/TrikoderOAuth2Bundle.php
+++ b/TrikoderOAuth2Bundle.php
@@ -6,22 +6,33 @@ namespace Trikoder\Bundle\OAuth2Bundle;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\GrantOdm;
+use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\RedirectUriOdm;
+use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\ScopeOdm;
 use Trikoder\Bundle\OAuth2Bundle\DependencyInjection\Security\OAuth2Factory;
 use Trikoder\Bundle\OAuth2Bundle\DependencyInjection\TrikoderOAuth2Extension;
 
 final class TrikoderOAuth2Bundle extends Bundle
 {
+
     /**
      * {@inheritdoc}
+     * @throws MappingException
      */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
 
         if (class_exists(DoctrineMongoDBMappingsPass::class)) {
+            Type::addType('oauth2_grant', GrantOdm::class);
+            Type::addType('oauth2_redirect_uri', RedirectUriOdm::class);
+            Type::addType('oauth2_scope', ScopeOdm::class);
+
             $this->configureDoctrineMongoExtension($container);
         } else {
             $this->configureDoctrineOrmExtension($container);

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,13 @@
     ],
     "require": {
         "php": ">=7.2",
-        "doctrine/doctrine-bundle": "^1.8|^2.0",
-        "doctrine/orm": "^2.6",
+        "doctrine/doctrine-bundle": "^2.0",
         "league/oauth2-server": "^7.2",
         "psr/http-factory": "^1.0",
-        "sensio/framework-extra-bundle": "^5.3",
-        "symfony/framework-bundle": "^3.4|^4.2",
-        "symfony/psr-http-message-bridge": "^1.2",
-        "symfony/security-bundle": "^3.4|^4.2"
+        "sensio/framework-extra-bundle": "^5.5",
+        "symfony/framework-bundle": "^3.4|^4.2|^5.0",
+        "symfony/psr-http-message-bridge": "^1.3",
+        "symfony/security-bundle": "^3.4|^4.2|^5.0"
     },
     "require-dev": {
         "ext-timecop": "*",
@@ -28,8 +27,8 @@
         "friendsofphp/php-cs-fixer": "2.16.0",
         "nyholm/psr7": "^1.1",
         "phpunit/phpunit": "^8.4",
-        "symfony/browser-kit": "^3.4|^4.2",
-        "symfony/phpunit-bridge": "^3.4|^4.4",
+        "symfony/browser-kit": "^3.4|^4.2|^5.0",
+        "symfony/phpunit-bridge": "^3.4|^4.4|^5.0",
         "zendframework/zend-diactoros": "^2.1"
     },
     "autoload": {
@@ -55,7 +54,7 @@
             "dev-master": "3.x-dev"
         },
         "symfony": {
-            "require": "4.4.*"
+            "require": "5.*"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": ">=7.2",
         "doctrine/doctrine-bundle": "^2.0.3",
+        "doctrine/mongodb-odm-bundle": "^4.1",
         "league/oauth2-server": "^7.2",
         "psr/http-factory": "^1.0",
         "sensio/framework-extra-bundle": "^5.5",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/doctrine-bundle": "^2.0.3",
         "league/oauth2-server": "^7.2",
         "psr/http-factory": "^1.0",
         "sensio/framework-extra-bundle": "^5.5",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
     "require-dev": {
         "ext-timecop": "*",
         "ext-xdebug": "*",
+        "doctrine/mongodb-odm": "^2.0",
+        "doctrine/orm": "^2.7",
         "friendsofphp/php-cs-fixer": "2.16.0",
         "nyholm/psr7": "^1.1",
         "phpunit/phpunit": "^8.4",

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --update --no-cache --virtual .build-deps \
         libxml2-dev \
         libzip-dev \
         zlib-dev \
+        openssl-dev \
     && docker-php-ext-install -j $(getconf _NPROCESSORS_ONLN) \
         xml \
         zip \

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -24,9 +24,11 @@ RUN apk add --update --no-cache --virtual .build-deps \
     && pecl install \
         xdebug-${XDEBUG_VERSION} \
         timecop-${TIMECOP_VERSION} \
+        mongodb \
     && docker-php-ext-enable \
         xdebug \
         timecop \
+        mongodb \
     && apk del --purge .build-deps
 
 RUN echo '[xdebug]' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,12 @@ services:
         image: trikoder/oauth2-bundle
         volumes:
             - .:/app/src
+        links:
+            - mongo
+    mongo:
+        environment:
+            - MONGO_INITDB_DATABASE=test
+            - MONGO_INITDB_ROOT_PASSWORD=test
+            - MONGO_INITDB_ROOT_USERNAME=test
+        image: mongo
+


### PR DESCRIPTION
This work in progress Pull Request add support to Doctrine ODM (MongoDB).   

Here are the main changes of this PR:
* Composer has been updated to support Symfony 5.x.
* Adding required package `doctrine/mongodb-odm-bundle`
* Updating Docker configuration, adding a mongodb container
* Updating code to check if Doctrine ORM or ODM is used
* Add and register custom types for Doctrine ODM
* Add Doctrine ODM model mapping files

## Requirements
* Bundles `doctrine/doctrine-bundle` and `doctrine/mongodb-odm-bundle` should be removed from requirements.

In that case, this bundle should be installed using:
```sh
composer require trikoder/oauth2-bundle nyholm/psr7 doctrine/doctrine-bundle
```
OR
```sh
composer require trikoder/oauth2-bundle nyholm/psr7 doctrine/mongodb-odm-bundle
```