### PR TITLE
Force type casting of alias for container to be compatible with declare(strict_types=1);

### DIFF
--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -283,7 +283,7 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
     {
         $scopeManager = $container
             ->getDefinition(
-                $container->getAlias(ScopeManagerInterface::class)
+                (string)$container->getAlias(ScopeManagerInterface::class)
             )
         ;
 


### PR DESCRIPTION
Very simple PR to allow compatibility of the extension loader with `declare(strict_types=1);`
The type-casting is default behavior of PHP, but must be explicit when `declare(strict_types=1);` is present. Backwards compatibility is present.

Without explicit type-casting the exception thrown is
```
Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Argument 1 passed to Symfony\Component\DependencyInjection\ContainerBuilder::getDefinition() must be of the type string, object given, called in /var/www/vendor/trikoder/oauth2-bundle/DependencyInjection/TrikoderOAuth2Extension.php on line 286 in /var/www/vendor/symfony/dependency-injection/ContainerBuilder.php:977
Stack trace:
#0 /var/www/vendor/trikoder/oauth2-bundle/DependencyInjection/TrikoderOAuth2Extension.php(286): Symfony\Component\DependencyInjection\ContainerBuilder->getDefinition(Object(Symfony\Component\DependencyInjection\Alias))
#1 /var/www/vendor/trikoder/oauth2-bundle/DependencyInjection/TrikoderOAuth2Extension.php(58): Trikoder\Bundle\OAuth2Bundle\DependencyInjection\TrikoderOAuth2Extension->configureScopes(Object(Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationContainerBuilder), Array)
#2 /var/www/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(76): Trikoder\Bundle\OAuth in /var/www/vendor/symfony/dependency-injection/ContainerBuilder.php on line 977
```