### PR TITLE
Update debugging documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ dev/bin/php composer test
 You can run the debugger using the following command:
 
 ```sh
-dev/bin/php-debug vendor/bin/phpunit
+dev/bin/php-debug -d timecop.func_override=1 vendor/bin/phpunit
 ```
 
 Make sure your IDE is setup properly, for more information check out the [dedicated documentation](docs/debugging.md).


### PR DESCRIPTION
In https://github.com/trikoder/oauth2-bundle/pull/141 we forgot to update the debugging section in the README.md. As timecop function overriding is now disabled by default in our Docker image running this line (without the change in this PR) would result in a bunch of tests failing.