### PR TITLE
Remove the timecop.func_override setting from composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
     - dev/bin/php composer update --ansi --prefer-dist
 
 script:
-    - dev/bin/php composer test -- --colors=always --coverage-clover=coverage.xml --debug
+    - dev/bin/php-test composer test -- --colors=always --coverage-clover=coverage.xml --debug
     - dev/bin/php composer lint -- --ansi --diff --dry-run --using-cache=no --verbose
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ dev/bin/php composer install
 You can run the test suite using the following command:
 
 ```sh
-dev/bin/php composer test
+dev/bin/php-test composer test
 ```
 
 ### Debugging
@@ -183,7 +183,7 @@ dev/bin/php composer test
 You can run the debugger using the following command:
 
 ```sh
-dev/bin/php-debug -d timecop.func_override=1 vendor/bin/phpunit
+dev/bin/php-debug vendor/bin/phpunit
 ```
 
 Make sure your IDE is setup properly, for more information check out the [dedicated documentation](docs/debugging.md).

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "scripts": {
         "lint": "php-cs-fixer fix",
-        "test": "php -d timecop.func_override=1 vendor/bin/phpunit"
+        "test": "phpunit"
     },
     "suggest": {
         "nelmio/cors-bundle": "For handling CORS requests",

--- a/dev/bin/php-test
+++ b/dev/bin/php-test
@@ -5,7 +5,5 @@ set -e
 readonly BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 
 "${BASE_DIR}"/docker-compose run --rm --no-deps \
-    -e PHP_IDE_CONFIG=serverName="${PHP_IDE_CONFIG:-oauth}" \
-    -e XDEBUG_REMOTE_AUTOSTART=1 \
     -e TIMECOP_FUNC_OVERRIDE=1 \
     php "$@"

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -9,6 +9,9 @@ ARG PHP_CS_FIXER_VERSION=2.16.1
 ARG TIMECOP_VERSION=1.2.10
 ARG XDEBUG_VERSION=2.9.2
 
+ENV XDEBUG_REMOTE_AUTOSTART 0
+ENV TIMECOP_FUNC_OVERRIDE 0
+
 # This is where we're going to store all of our non-project specific binaries
 RUN mkdir -p /app/bin
 ENV PATH /app/bin:$PATH
@@ -31,12 +34,13 @@ RUN apk add --update --no-cache --virtual .build-deps \
     && apk del --purge .build-deps
 
 RUN echo '[xdebug]' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && echo 'xdebug.remote_autostart = ${XDEBUG_REMOTE_AUTOSTART}' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_enable = 1' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_connect_back = 0' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_host = %XDEBUG_REMOTE_HOST%' >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 RUN echo '[timecop]' >> /usr/local/etc/php/conf.d/docker-php-ext-timecop.ini \
-    && echo 'timecop.func_override = 0' >> /usr/local/etc/php/conf.d/docker-php-ext-timecop.ini
+    && echo 'timecop.func_override = ${TIMECOP_FUNC_OVERRIDE}' >> /usr/local/etc/php/conf.d/docker-php-ext-timecop.ini
 
 # Utilities needed to run this image
 RUN apk add --update --no-cache \


### PR DESCRIPTION
I added a new `php-test` wrapper script which has the `timecop.func_override` setting set to `1`. I also added the setting to `php-debug` since I don't see a case in which we would have a need for it with  `timecop.func_override` set to `0`.