### PR TITLE
Fix boolean column default value mapping for MariaDB

### DIFF
--- a/Resources/config/doctrine/model/Client.orm.xml
+++ b/Resources/config/doctrine/model/Client.orm.xml
@@ -11,7 +11,7 @@
         <field name="active" type="boolean" />
         <field name="allowPlainTextPkce" column="allow_plain_text_pkce" type="boolean">
             <options>
-                <option name="default">false</option>
+                <option name="default">0</option>
             </options>
         </field>
     </entity>


### PR DESCRIPTION
Fixes https://github.com/trikoder/oauth2-bundle/commit/4562a1ff306375fd651aa91c85d0d4fd6f4c1b13#commitcomment-37463516

```
ALTER TABLE
  oauth2_client
ADD
  allow_plain_text_pkce TINYINT(1) DEFAULT 'false' NOT NULL,
  CHANGE secret secret VARCHAR(128) DEFAULT NULL;
```

This query is valid for MySQL and SQLite but it is not valid for MariaDB.