### PR TITLE
Fix returned column value

### DIFF
--- a/Command/ListClientsCommand.php
+++ b/Command/ListClientsCommand.php
@@ -115,7 +115,7 @@ final class ListClientsCommand extends Command
             ];
 
             return array_map(static function (string $column) use ($values): string {
-                return $values[$column];
+                return $values[$column] ?? '';
             }, $columns);
         }, $clients);
     }

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "4.x-dev"
         }
     }
 }


### PR DESCRIPTION
The returned column value does not comply with the return type annotation as it can be null|string but a string is expected. It is safe here to return empty string if the value is actually null.