### PR TITLE
Versioning and contribution documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+and this project [adheres to Semantic Versioning, but only for the public API](README.md#versioning).
 
 ## [3.1.1] - 2020-04-10
 ### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+All contributions are **welcome** and **very much appreciated**.
+
+We accept contributions via Pull Requests on [Github](https://github.com/trikoder/oauth2-bundle).
+
+## Pull Request guidelines
+
+- **Add tests!** - We strongly encourage adding tests as well since the PR might not be accepted without them.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+## Development
+
+[Docker](https://www.docker.com/) 18.03+ and [Docker Compose](https://github.com/docker/compose) 1.13+ are required for the development environment.
+
+### Building the environment
+
+Make sure your Docker images are all built and up-to-date using the following command:
+
+```sh
+dev/bin/docker-compose build
+```
+
+> **NOTE:** You can target a different version of PHP during development by appending the `--build-arg PHP_VERSION=<version>` argument.
+
+After that, install all the needed packages required to develop the project:
+
+```sh
+dev/bin/php composer install
+```
+
+### Debugging
+
+You can run the debugger using the following command:
+
+```sh
+dev/bin/php-debug vendor/bin/phpunit
+```
+
+Make sure your IDE is setup properly, for more information check out the [dedicated documentation](docs/debugging.md).
+
+### Code linting
+
+This bundle enforces the PSR-2 and Symfony code standards during development by using the [PHP CS Fixer](https://cs.sensiolabs.org/) utility. Before committing any code, you can run the utility to fix any potential rule violations:
+
+```sh
+dev/bin/php composer lint
+```
+
+### Testing
+
+You can run the whole test suite using the following command:
+
+```sh
+dev/bin/php-test composer test
+```
+
+**Happy coding**!

--- a/README.md
+++ b/README.md
@@ -153,51 +153,9 @@ security:
 * [Password grant handling](docs/password-grant-handling.md)
 * [Implementing custom grant type](docs/implementing-custom-grant-type.md)
 
-## Development
+## Contributing
 
-[Docker](https://www.docker.com/) 18.03+ and [Docker Compose](https://github.com/docker/compose) 1.13+ are required for the development environment.
-
-### Building the environment
-
-Make sure your Docker images are all built and up-to-date using the following command:
-
-```sh
-dev/bin/docker-compose build
-```
-
-> **NOTE:** You can target a different version of PHP during development by appending the `--build-arg PHP_VERSION=<version>` argument.
-
-After that, install all the needed packages required to develop the project:
-
-```sh
-dev/bin/php composer install
-```
-
-### Testing
-
-You can run the test suite using the following command:
-
-```sh
-dev/bin/php-test composer test
-```
-
-### Debugging
-
-You can run the debugger using the following command:
-
-```sh
-dev/bin/php-debug vendor/bin/phpunit
-```
-
-Make sure your IDE is setup properly, for more information check out the [dedicated documentation](docs/debugging.md).
-
-### Code linting
-
-This bundle enforces the PSR-2 and Symfony code standards during development using the [PHP CS Fixer](https://cs.sensiolabs.org/) utility. Before committing any code, you can run the utility so it can fix any potential rule violations for you:
-
-```sh
-dev/bin/php composer lint
-```
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ This bundle enforces the PSR-2 and Symfony code standards during development usi
 dev/bin/php composer lint
 ```
 
+## Versioning
+
+This project adheres to [Semantic Versioning 2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+However, starting with version 4, we only promise to follow SemVer on structural elements marked with the [@api tag](https://github.com/php-fig/fig-standards/blob/2668020622d9d9eaf11d403bc1d26664dfc3ef8e/proposed/phpdoc-tags.md#51-api).
+
 ## Changes
 
 All the package releases are recorded in the [CHANGELOG](CHANGELOG.md) file.


### PR DESCRIPTION
I have added a proposal for versioning policy and contributing guidelines (shamelessly ripped off thephpleague/skeleton).

One change I'd like to stand out concerns defining public API of the package (look for `@api` in the diff) and how it affects versioning.

This PR should close #182 and maaaybe #180?