### PR TITLE
Fixes list client command output with a public client

### DIFF
--- a/Command/ListClientsCommand.php
+++ b/Command/ListClientsCommand.php
@@ -114,7 +114,7 @@ final class ListClientsCommand extends Command
                 'grant type' => implode(', ', $client->getGrants()),
             ];
 
-            return array_map(static function (string $column) use ($values): string {
+            return array_map(static function (string $column) use ($values): ?string {
                 return $values[$column];
             }, $columns);
         }, $clients);

--- a/Tests/Acceptance/ListClientsCommandTest.php
+++ b/Tests/Acceptance/ListClientsCommandTest.php
@@ -35,6 +35,28 @@ TABLE;
         $this->assertEquals(trim($expected), trim($output));
     }
 
+    public function testListPublicClients(): void
+    {
+        $client = new Client('foobar', null);
+        $this->getClientManager()->save($client);
+
+        $command = $this->command();
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+        ]);
+        $output = $commandTester->getDisplay();
+        $expected = <<<TABLE
+ ------------ -------- ------- -------------- ------------ 
+  identifier   secret   scope   redirect uri   grant type  
+ ------------ -------- ------- -------------- ------------ 
+  foobar                                                   
+ ------------ -------- ------- -------------- ------------ 
+TABLE;
+
+        $this->assertEquals(trim($expected), trim($output));
+    }
+
     public function testListClientsEmpty(): void
     {
         $command = $this->command();


### PR DESCRIPTION
When listing clients using the corresponding command and having a public client (ie no secret), invalid typehint raises an exception.
This PR fixes that behavior and adds the corresponding test.