### PR TITLE
Use docker hub to speedup build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ env:
     - PHP_VERSION=7.4 COMPOSER_FLAGS="--prefer-lowest" SYMFONY_REQUIRE=5.0.*
 
 install:
-    - dev/bin/docker-compose build --build-arg PHP_VERSION=${PHP_VERSION} php
+    - dev/bin/docker-compose pull
+    - dev/bin/php -v
 
 before_script:
     # Our docker image has symfony/flex installed to make sure SYMFONY_REQUIRE is working

--- a/dev/bin/docker-compose
+++ b/dev/bin/docker-compose
@@ -5,4 +5,6 @@ set -e
 export HOST_USER_ID=$(id -u)
 export HOST_GROUP_ID=$(id -g)
 
+export PHP_VERSION=${PHP_VERSION:-7.4}
+
 docker-compose "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
 version: '3'
 services:
     php:
-        build: ./dev/docker
+        image: hypemc/oauth2-bundle:${PHP_VERSION}
+        build:
+            context: ./dev/docker
+            args:
+                PHP_VERSION: ${PHP_VERSION}
         environment:
             HOST_USER_ID: ${HOST_USER_ID}
             HOST_GROUP_ID: ${HOST_GROUP_ID}
             PSR_HTTP_PROVIDER: ${PSR_HTTP_PROVIDER:-nyholm}
             SYMFONY_REQUIRE: ${SYMFONY_REQUIRE:-4.4.*}
-        image: trikoder/oauth2-bundle
         volumes:
             - .:/app/src


### PR DESCRIPTION
Build time decreased from circa [13 min 50 sec](https://travis-ci.org/github/trikoder/oauth2-bundle/builds/675991879) to [7 min 43 sec](https://travis-ci.org/github/trikoder/oauth2-bundle/builds/675999835).

TODO: We would need an official docker hub account.