### PR TITLE
Set "CASCADE" on delete for AuthorizationCode/Client association

### DIFF
--- a/Resources/config/doctrine/model/AuthorizationCode.orm.xml
+++ b/Resources/config/doctrine/model/AuthorizationCode.orm.xml
@@ -15,7 +15,7 @@
         <field name="scopes" type="oauth2_scope" nullable="true" />
         <field name="revoked" type="boolean" />
         <many-to-one field="client" target-entity="Trikoder\Bundle\OAuth2Bundle\Model\Client">
-            <join-column name="client" referenced-column-name="identifier" nullable="false" />
+            <join-column name="client" referenced-column-name="identifier" nullable="false" on-delete="CASCADE" />
         </many-to-one>
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
Same as `AccessToken` model:
https://github.com/trikoder/oauth2-bundle/blob/6ea74bcef303f1a0b70975336ac0878c381cc21e/Resources/config/doctrine/model/AccessToken.orm.xml#L18

if the a Client row is being deleted, then the related authorization codes should be delete too.