### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This package is currently in the active development.
 1. Require the bundle and a PSR 7/17 implementation with Composer:
 
     ```sh
-    composer require trikoder/oauth2-bundle nyholm/psr7
+    composer require trikoder/oauth2-bundle nyholm/psr7 symfony-bundles/json-request-bundle
     ```
 
     If your project is managed using [Symfony Flex](https://github.com/symfony/flex), the rest of the steps are not required. Just follow the post-installation instructions instead! :tada:


### PR DESCRIPTION
Add symfony-bundles/json-request-bundle package to parse json content on oauth request. By default json content is handle as string and did not work with oauth2 request json content