### PR TITLE
Add passing previous exception

### DIFF
--- a/Security/Firewall/OAuth2Listener.php
+++ b/Security/Firewall/OAuth2Listener.php
@@ -68,7 +68,7 @@ final class OAuth2Listener
             /** @var OAuth2Token $authenticatedToken */
             $authenticatedToken = $this->authenticationManager->authenticate($this->oauth2TokenFactory->createOAuth2Token($request, null, $this->providerKey));
         } catch (AuthenticationException $e) {
-            throw Oauth2AuthenticationFailedException::create($e->getMessage());
+            throw new Oauth2AuthenticationFailedException($e->getMessage(), 401, $e);
         }
 
         if (!$this->isAccessToRouteGranted($event->getRequest(), $authenticatedToken)) {


### PR DESCRIPTION
Usefull for ConvertExceptionToResponseListener to keep the OAuth2 rfc response format and get the possibility to response a valid json.

I didn't update the listener because it's a BC break. For exemple it can look like this :

```php
<?php

declare(strict_types=1);

namespace Trikoder\Bundle\OAuth2Bundle\EventListener;

use Psr\Http\Message\ResponseFactoryInterface;
use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpKernel\Event\ExceptionEvent;
use Trikoder\Bundle\OAuth2Bundle\Security\Exception\InsufficientScopesException;
use Trikoder\Bundle\OAuth2Bundle\Security\Exception\OAuth2AuthenticationFailedException;

/**
 * @author Tobias Nyholm <tobias.nyholm@gmail.com>
 */
final class ConvertExceptionToResponseListener
{
    private ResponseFactoryInterface $responseFactory;

    public function __construct(ResponseFactoryInterface $responseFactory) {
        $this->responseFactory = $responseFactory;
    }

    public function onKernelException(ExceptionEvent $event): void
    {
        $exception = $event->getThrowable();
        if ($exception instanceof InsufficientScopesException || $exception instanceof OAuth2AuthenticationFailedException) {
            $leagueException = $exception->getPrevious()->getPrevious(); // not so sexy
            $httpFoundationFactory = new HttpFoundationFactory();
            $event->setResponse($httpFoundationFactory->createResponse($leagueException->generateHttpResponse($this->responseFactory->createResponse())));
        }
    }
}
```