### PR TITLE
Crypt client secret

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,10 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('ROLE_OAUTH2_')
                     ->cannotBeEmpty()
                 ->end()
+                ->booleanNode('crypt_client_secret')
+                    ->info('Crypt the client secret in database')
+                    ->defaultFalse() // to prevent BC Break
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -30,11 +30,13 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Trikoder\Bundle\OAuth2Bundle\Command\CreateClientCommand;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Grant as GrantType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\RedirectUri as RedirectUriType;
 use Trikoder\Bundle\OAuth2Bundle\DBAL\Type\Scope as ScopeType;
 use Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener;
 use Trikoder\Bundle\OAuth2Bundle\League\AuthorizationServer\GrantTypeInterface;
+use Trikoder\Bundle\OAuth2Bundle\League\Repository\ClientRepository;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AuthorizationCodeManager;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager;
@@ -62,6 +64,12 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
         $this->configureAuthorizationServer($container, $config['authorization_server']);
         $this->configureResourceServer($container, $config['resource_server']);
         $this->configureScopes($container, $config['scopes']);
+
+        $container->getDefinition(CreateClientCommand::class)
+            ->setArgument(1, $config['crypt_client_secret']);
+
+        $container->getDefinition(ClientRepository::class)
+            ->setArgument(1, true/*$config['crypt_client_secret']*/);
 
         $container->getDefinition(OAuth2TokenFactory::class)
             ->setArgument(0, $config['role_prefix']);

--- a/League/Repository/ClientRepository.php
+++ b/League/Repository/ClientRepository.php
@@ -16,9 +16,15 @@ final class ClientRepository implements ClientRepositoryInterface
      */
     private $clientManager;
 
-    public function __construct(ClientManagerInterface $clientManager)
+    /**
+     * @var bool
+     */
+    private $cryptClientSecret;
+
+    public function __construct(ClientManagerInterface $clientManager, bool $cryptClientSecret = false)
     {
         $this->clientManager = $clientManager;
+        $this->cryptClientSecret = $cryptClientSecret;
     }
 
     /**
@@ -54,11 +60,15 @@ final class ClientRepository implements ClientRepositoryInterface
             return false;
         }
 
-        if (!$client->isConfidential() || hash_equals($client->getSecret(), (string) $clientSecret)) {
+        if (!$client->isConfidential()) {
             return true;
         }
 
-        return false;
+        if ($this->cryptClientSecret) {
+            return password_verify((string) $clientSecret, $client->getSecret());
+        }
+
+        return hash_equals($client->getSecret(), (string) $clientSecret);
     }
 
     private function buildClientEntity(ClientModel $client): ClientEntity

--- a/Tests/Integration/ClientRepositoryTest.php
+++ b/Tests/Integration/ClientRepositoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Integration;
+
+use Trikoder\Bundle\OAuth2Bundle\League\Repository\ClientRepository;
+use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Tests\Integration\AbstractIntegrationTest;
+
+/**
+ * @author Florent Blaison
+ */
+final class ClientRepositoryTest extends AbstractIntegrationTest
+{
+    public function testValidateClientWithPlainSecret(): void
+    {
+        $identifier = 'foo';
+        $secret = 'bar';
+
+        $client = new Client($identifier, $secret);
+
+        $this->clientManager->save($client);
+
+        $this->assertSame($client, $this->clientManager->find($identifier));
+
+        $clientRepository = new ClientRepository($this->clientManager, false);
+
+        $this->assertTrue($clientRepository->validateClient($identifier, $secret, null));
+    }
+
+    public function testValidateClientWithCryptSecret(): void
+    {
+        $identifier = 'foo';
+        $secret = 'bar';
+
+        $client = new Client($identifier, password_hash($secret, PASSWORD_DEFAULT));
+
+        $this->clientManager->save($client);
+
+        $this->assertSame($client, $this->clientManager->find($identifier));
+
+        $clientRepository = new ClientRepository($this->clientManager, true);
+
+        $this->assertTrue($clientRepository->validateClient($identifier, $secret, null));
+    }
+}


### PR DESCRIPTION
Beginning proposal for #38 

For now it's just something really simple but we can imagine add thoses features :
- UpdateSecretCommand to migrate already existing client
- Add field to client model to know if the secret is plain text or crypt to handle secret verification (and to optimise the UpdateSecretCommand, not crypt a secret already crypted)
- Add the ability to "hot crypt" secret => when the `crypt_client_secret` is set to `true` migrate automatically a client when we retrieve it from the database
- Add a new class like `ClientSecretVerifier` to crypt and verify it in one entry point