### PR TITLE
Use fixed column names and add indices

### DIFF
--- a/Resources/config/doctrine/model/AccessToken.orm.xml
+++ b/Resources/config/doctrine/model/AccessToken.orm.xml
@@ -5,13 +5,18 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
     <entity name="Trikoder\Bundle\OAuth2Bundle\Model\AccessToken" table="oauth2_access_token">
+        <indexes>
+            <index columns="expiry" />
+            <index columns="user_identifier" />
+            <index columns="revoked" />
+        </indexes>
         <id name="identifier" type="string" length="80">
             <options>
                 <option name="fixed">true</option>
             </options>
         </id>
         <field name="expiry" type="datetime_immutable" />
-        <field name="userIdentifier" type="string" length="128" nullable="true" />
+        <field name="userIdentifier" column="user_identifier" type="string" length="128" nullable="true" />
         <field name="scopes" type="oauth2_scope" nullable="true" />
         <field name="revoked" type="boolean" />
         <many-to-one field="client" target-entity="Trikoder\Bundle\OAuth2Bundle\Model\Client">

--- a/Resources/config/doctrine/model/AuthorizationCode.orm.xml
+++ b/Resources/config/doctrine/model/AuthorizationCode.orm.xml
@@ -5,13 +5,18 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
     <entity name="Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode" table="oauth2_authorization_code">
+        <indexes>
+            <index columns="expiry" />
+            <index columns="user_identifier" />
+            <index columns="revoked" />
+        </indexes>
         <id name="identifier" type="string" length="80">
             <options>
                 <option name="fixed">true</option>
             </options>
         </id>
         <field name="expiry" type="datetime_immutable" />
-        <field name="userIdentifier" type="string" length="128" nullable="true" />
+        <field name="userIdentifier" column="user_identifier" type="string" length="128" nullable="true" />
         <field name="scopes" type="oauth2_scope" nullable="true" />
         <field name="revoked" type="boolean" />
         <many-to-one field="client" target-entity="Trikoder\Bundle\OAuth2Bundle\Model\Client">

--- a/Resources/config/doctrine/model/Client.orm.xml
+++ b/Resources/config/doctrine/model/Client.orm.xml
@@ -5,9 +5,12 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
     <entity name="Trikoder\Bundle\OAuth2Bundle\Model\Client" table="oauth2_client">
+        <indexes>
+            <index columns="active" />
+        </indexes>
         <id name="identifier" type="string" length="32" />
         <field name="secret" type="string" length="128" nullable="true" />
-        <field name="redirectUris" type="oauth2_redirect_uri" nullable="true" />
+        <field name="redirectUris" column="redirect_uris" type="oauth2_redirect_uri" nullable="true" />
         <field name="grants" type="oauth2_grant" nullable="true" />
         <field name="scopes" type="oauth2_scope" nullable="true" />
         <field name="active" type="boolean" />

--- a/Resources/config/doctrine/model/RefreshToken.orm.xml
+++ b/Resources/config/doctrine/model/RefreshToken.orm.xml
@@ -5,6 +5,10 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
     <entity name="Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken" table="oauth2_refresh_token">
+        <indexes>
+            <index columns="expiry" />
+            <index columns="revoked" />
+        </indexes>
         <id name="identifier" type="string" length="80">
             <options>
                 <option name="fixed">true</option>


### PR DESCRIPTION
Follow up to #197, turns out the naming strategy is only applied when there are no explicit names given to the columns.

~v3 bugfix or v4 feature?~ BC, has to be v4

Do we need to add explicit column names to all fields, eg someone has a custom strategy?

TODO: Explicit index names?