### PR TITLE
Decoupled models from managers

### DIFF
--- a/Manager/AccessTokenManagerInterface.php
+++ b/Manager/AccessTokenManagerInterface.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager;
 
-use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
+use Trikoder\Bundle\OAuth2Bundle\Model\AccessTokenInterface;
 
 /**
  * @method int clearRevoked() not defining this method is deprecated since version 3.2
  */
 interface AccessTokenManagerInterface
 {
-    public function find(string $identifier): ?AccessToken;
+    public function find(string $identifier): ?AccessTokenInterface;
 
-    public function save(AccessToken $accessToken): void;
+    public function save(AccessTokenInterface $accessToken): void;
 
     public function clearExpired(): int;
 }

--- a/Manager/AuthorizationCodeManagerInterface.php
+++ b/Manager/AuthorizationCodeManagerInterface.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager;
 
-use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
+use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCodeInterface;
 
 /**
  * @method int clearRevoked() not defining this method is deprecated since version 3.2
  */
 interface AuthorizationCodeManagerInterface
 {
-    public function find(string $identifier): ?AuthorizationCode;
+    public function find(string $identifier): ?AuthorizationCodeInterface;
 
-    public function save(AuthorizationCode $authCode): void;
+    public function save(AuthorizationCodeInterface $authCode): void;
 
     public function clearExpired(): int;
 }

--- a/Manager/ClientFilter.php
+++ b/Manager/ClientFilter.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager;
 
-use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
-use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri;
-use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+use Trikoder\Bundle\OAuth2Bundle\Model\GrantInterface;
+use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUriInterface;
+use Trikoder\Bundle\OAuth2Bundle\Model\ScopeInterface;
 
 final class ClientFilter
 {
     /**
-     * @var Grant[]
+     * @var GrantInterface[]
      */
     private $grants = [];
 
     /**
-     * @var RedirectUri[]
+     * @var RedirectUriInterface[]
      */
     private $redirectUris = [];
 
     /**
-     * @var Scope[]
+     * @var ScopeInterface[]
      */
     private $scopes = [];
 
@@ -30,17 +30,17 @@ final class ClientFilter
         return new static();
     }
 
-    public function addGrantCriteria(Grant ...$grants): self
+    public function addGrantCriteria(GrantInterface ...$grants): self
     {
         return $this->addCriteria($this->grants, ...$grants);
     }
 
-    public function addRedirectUriCriteria(RedirectUri ...$redirectUris): self
+    public function addRedirectUriCriteria(RedirectUriInterface ...$redirectUris): self
     {
         return $this->addCriteria($this->redirectUris, ...$redirectUris);
     }
 
-    public function addScopeCriteria(Scope ...$scopes): self
+    public function addScopeCriteria(ScopeInterface ...$scopes): self
     {
         return $this->addCriteria($this->scopes, ...$scopes);
     }
@@ -57,7 +57,7 @@ final class ClientFilter
     }
 
     /**
-     * @return Grant[]
+     * @return GrantInterface[]
      */
     public function getGrants(): array
     {
@@ -65,7 +65,7 @@ final class ClientFilter
     }
 
     /**
-     * @return RedirectUri[]
+     * @return RedirectUriInterface[]
      */
     public function getRedirectUris(): array
     {
@@ -73,7 +73,7 @@ final class ClientFilter
     }
 
     /**
-     * @return Scope[]
+     * @return ScopeInterface[]
      */
     public function getScopes(): array
     {

--- a/Manager/ClientManagerInterface.php
+++ b/Manager/ClientManagerInterface.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager;
 
-use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\ClientInterface;
 use Trikoder\Bundle\OAuth2Bundle\Service\ClientFinderInterface;
 
 interface ClientManagerInterface extends ClientFinderInterface
 {
-    public function save(Client $client): void;
+    public function save(ClientInterface $client): void;
 
-    public function remove(Client $client): void;
+    public function remove(ClientInterface $client): void;
 
     /**
-     * @return Client[]
+     * @return ClientInterface[]
      */
     public function list(?ClientFilter $clientFilter): array;
 }

--- a/Manager/Doctrine/AccessTokenManager.php
+++ b/Manager/Doctrine/AccessTokenManager.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
+use Trikoder\Bundle\OAuth2Bundle\Model\AccessTokenInterface;
 
 final class AccessTokenManager implements AccessTokenManagerInterface
 {
@@ -24,7 +25,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?AccessToken
+    public function find(string $identifier): ?AccessTokenInterface
     {
         return $this->entityManager->find(AccessToken::class, $identifier);
     }
@@ -32,7 +33,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(AccessToken $accessToken): void
+    public function save(AccessTokenInterface $accessToken): void
     {
         $this->entityManager->persist($accessToken);
         $this->entityManager->flush();

--- a/Manager/Doctrine/AuthorizationCodeManager.php
+++ b/Manager/Doctrine/AuthorizationCodeManager.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
+use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCodeInterface;
 
 final class AuthorizationCodeManager implements AuthorizationCodeManagerInterface
 {
@@ -24,7 +25,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?AuthorizationCode
+    public function find(string $identifier): ?AuthorizationCodeInterface
     {
         return $this->entityManager->find(AuthorizationCode::class, $identifier);
     }
@@ -32,7 +33,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
     /**
      * {@inheritdoc}
      */
-    public function save(AuthorizationCode $authorizationCode): void
+    public function save(AuthorizationCodeInterface $authorizationCode): void
     {
         $this->entityManager->persist($authorizationCode);
         $this->entityManager->flush();

--- a/Manager/Doctrine/ClientManager.php
+++ b/Manager/Doctrine/ClientManager.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientFilter;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\ClientInterface;
 
 final class ClientManager implements ClientManagerInterface
 {
@@ -24,7 +25,7 @@ final class ClientManager implements ClientManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?Client
+    public function find(string $identifier): ?ClientInterface
     {
         return $this->entityManager->find(Client::class, $identifier);
     }
@@ -32,7 +33,7 @@ final class ClientManager implements ClientManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(Client $client): void
+    public function save(ClientInterface $client): void
     {
         $this->entityManager->persist($client);
         $this->entityManager->flush();
@@ -41,7 +42,7 @@ final class ClientManager implements ClientManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function remove(Client $client): void
+    public function remove(ClientInterface $client): void
     {
         $this->entityManager->remove($client);
         $this->entityManager->flush();

--- a/Manager/Doctrine/RefreshTokenManager.php
+++ b/Manager/Doctrine/RefreshTokenManager.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
+use Trikoder\Bundle\OAuth2Bundle\Model\RefreshTokenInterface;
 
 final class RefreshTokenManager implements RefreshTokenManagerInterface
 {
@@ -24,7 +25,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?RefreshToken
+    public function find(string $identifier): ?RefreshTokenInterface
     {
         return $this->entityManager->find(RefreshToken::class, $identifier);
     }
@@ -32,7 +33,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(RefreshToken $refreshToken): void
+    public function save(RefreshTokenInterface $refreshToken): void
     {
         $this->entityManager->persist($refreshToken);
         $this->entityManager->flush();

--- a/Manager/InMemory/AccessTokenManager.php
+++ b/Manager/InMemory/AccessTokenManager.php
@@ -6,19 +6,19 @@ namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
 use DateTimeImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
-use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
+use Trikoder\Bundle\OAuth2Bundle\Model\AccessTokenInterface;
 
 final class AccessTokenManager implements AccessTokenManagerInterface
 {
     /**
-     * @var AccessToken[]
+     * @var AccessTokenInterface[]
      */
     private $accessTokens = [];
 
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?AccessToken
+    public function find(string $identifier): ?AccessTokenInterface
     {
         return $this->accessTokens[$identifier] ?? null;
     }
@@ -26,7 +26,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(AccessToken $accessToken): void
+    public function save(AccessTokenInterface $accessToken): void
     {
         $this->accessTokens[$accessToken->getIdentifier()] = $accessToken;
     }
@@ -36,7 +36,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
         $count = \count($this->accessTokens);
 
         $now = new DateTimeImmutable();
-        $this->accessTokens = array_filter($this->accessTokens, static function (AccessToken $accessToken) use ($now): bool {
+        $this->accessTokens = array_filter($this->accessTokens, static function (AccessTokenInterface $accessToken) use ($now): bool {
             return $accessToken->getExpiry() >= $now;
         });
 
@@ -47,7 +47,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
     {
         $count = \count($this->accessTokens);
 
-        $this->accessTokens = array_filter($this->accessTokens, static function (AccessToken $accessToken): bool {
+        $this->accessTokens = array_filter($this->accessTokens, static function (AccessTokenInterface $accessToken): bool {
             return !$accessToken->isRevoked();
         });
 

--- a/Manager/InMemory/AuthorizationCodeManager.php
+++ b/Manager/InMemory/AuthorizationCodeManager.php
@@ -7,6 +7,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 use DateTimeImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
+use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCodeInterface;
 
 final class AuthorizationCodeManager implements AuthorizationCodeManagerInterface
 {
@@ -15,12 +16,12 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
      */
     private $authorizationCodes = [];
 
-    public function find(string $identifier): ?AuthorizationCode
+    public function find(string $identifier): ?AuthorizationCodeInterface
     {
         return $this->authorizationCodes[$identifier] ?? null;
     }
 
-    public function save(AuthorizationCode $authorizationCode): void
+    public function save(AuthorizationCodeInterface $authorizationCode): void
     {
         $this->authorizationCodes[$authorizationCode->getIdentifier()] = $authorizationCode;
     }
@@ -30,7 +31,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
         $count = \count($this->authorizationCodes);
 
         $now = new DateTimeImmutable();
-        $this->authorizationCodes = array_filter($this->authorizationCodes, static function (AuthorizationCode $authorizationCode) use ($now): bool {
+        $this->authorizationCodes = array_filter($this->authorizationCodes, static function (AuthorizationCodeInterface $authorizationCode) use ($now): bool {
             return $authorizationCode->getExpiryDateTime() >= $now;
         });
 
@@ -41,7 +42,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
     {
         $count = \count($this->authorizationCodes);
 
-        $this->authorizationCodes = array_filter($this->authorizationCodes, static function (AuthorizationCode $authorizationCode): bool {
+        $this->authorizationCodes = array_filter($this->authorizationCodes, static function (AuthorizationCodeInterface $authorizationCode): bool {
             return !$authorizationCode->isRevoked();
         });
 

--- a/Manager/InMemory/ClientManager.php
+++ b/Manager/InMemory/ClientManager.php
@@ -6,19 +6,19 @@ namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientFilter;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
-use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\ClientInterface;
 
 final class ClientManager implements ClientManagerInterface
 {
     /**
-     * @var Client[]
+     * @var ClientInterface[]
      */
     private $clients = [];
 
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?Client
+    public function find(string $identifier): ?ClientInterface
     {
         return $this->clients[$identifier] ?? null;
     }
@@ -26,7 +26,7 @@ final class ClientManager implements ClientManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(Client $client): void
+    public function save(ClientInterface $client): void
     {
         $this->clients[$client->getIdentifier()] = $client;
     }
@@ -34,7 +34,7 @@ final class ClientManager implements ClientManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function remove(Client $client): void
+    public function remove(ClientInterface $client): void
     {
         unset($this->clients[$client->getIdentifier()]);
     }
@@ -48,7 +48,7 @@ final class ClientManager implements ClientManagerInterface
             return $this->clients;
         }
 
-        return array_filter($this->clients, static function (Client $client) use ($clientFilter): bool {
+        return array_filter($this->clients, static function (ClientInterface $client) use ($clientFilter): bool {
             $grantsPassed = self::passesFilter($client->getGrants(), $clientFilter->getGrants());
             $scopesPassed = self::passesFilter($client->getScopes(), $clientFilter->getScopes());
             $redirectUrisPassed = self::passesFilter($client->getRedirectUris(), $clientFilter->getRedirectUris());

--- a/Manager/InMemory/RefreshTokenManager.php
+++ b/Manager/InMemory/RefreshTokenManager.php
@@ -6,19 +6,19 @@ namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
 use DateTimeImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
-use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
+use Trikoder\Bundle\OAuth2Bundle\Model\RefreshTokenInterface;
 
 final class RefreshTokenManager implements RefreshTokenManagerInterface
 {
     /**
-     * @var RefreshToken[]
+     * @var RefreshTokenInterface[]
      */
     private $refreshTokens = [];
 
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?RefreshToken
+    public function find(string $identifier): ?RefreshTokenInterface
     {
         return $this->refreshTokens[$identifier] ?? null;
     }
@@ -26,7 +26,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(RefreshToken $refreshToken): void
+    public function save(RefreshTokenInterface $refreshToken): void
     {
         $this->refreshTokens[$refreshToken->getIdentifier()] = $refreshToken;
     }
@@ -36,7 +36,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
         $count = \count($this->refreshTokens);
 
         $now = new DateTimeImmutable();
-        $this->refreshTokens = array_filter($this->refreshTokens, static function (RefreshToken $refreshToken) use ($now): bool {
+        $this->refreshTokens = array_filter($this->refreshTokens, static function (RefreshTokenInterface $refreshToken) use ($now): bool {
             return $refreshToken->getExpiry() >= $now;
         });
 
@@ -47,7 +47,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
     {
         $count = \count($this->refreshTokens);
 
-        $this->refreshTokens = array_filter($this->refreshTokens, static function (RefreshToken $refreshToken): bool {
+        $this->refreshTokens = array_filter($this->refreshTokens, static function (RefreshTokenInterface $refreshToken): bool {
             return !$refreshToken->isRevoked();
         });
 

--- a/Manager/InMemory/ScopeManager.php
+++ b/Manager/InMemory/ScopeManager.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
 use Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface;
-use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+use Trikoder\Bundle\OAuth2Bundle\Model\ScopeInterface;
 
 final class ScopeManager implements ScopeManagerInterface
 {
     /**
-     * @var Scope[]
+     * @var ScopeInterface[]
      */
     private $scopes = [];
 
     /**
      * {@inheritdoc}
      */
-    public function find(string $identifier): ?Scope
+    public function find(string $identifier): ?ScopeInterface
     {
         return $this->scopes[$identifier] ?? null;
     }
@@ -25,7 +25,7 @@ final class ScopeManager implements ScopeManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(Scope $scope): void
+    public function save(ScopeInterface $scope): void
     {
         $this->scopes[(string) $scope] = $scope;
     }

--- a/Manager/RefreshTokenManagerInterface.php
+++ b/Manager/RefreshTokenManagerInterface.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager;
 
-use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
+use Trikoder\Bundle\OAuth2Bundle\Model\RefreshTokenInterface;
 
 /**
  * @method int clearRevoked() not defining this method is deprecated since version 3.2
  */
 interface RefreshTokenManagerInterface
 {
-    public function find(string $identifier): ?RefreshToken;
+    public function find(string $identifier): ?RefreshTokenInterface;
 
-    public function save(RefreshToken $refreshToken): void;
+    public function save(RefreshTokenInterface $refreshToken): void;
 
     public function clearExpired(): int;
 }

--- a/Manager/ScopeManagerInterface.php
+++ b/Manager/ScopeManagerInterface.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager;
 
-use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+use Trikoder\Bundle\OAuth2Bundle\Model\ScopeInterface;
 
 interface ScopeManagerInterface
 {
-    public function find(string $identifier): ?Scope;
+    public function find(string $identifier): ?ScopeInterface;
 
-    public function save(Scope $scope): void;
+    public function save(ScopeInterface $scope): void;
 }

--- a/Model/AccessToken.php
+++ b/Model/AccessToken.php
@@ -6,7 +6,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Model;
 
 use DateTimeInterface;
 
-class AccessToken
+class AccessToken implements AccessTokenInterface
 {
     /**
      * @var string
@@ -24,12 +24,12 @@ class AccessToken
     private $userIdentifier;
 
     /**
-     * @var Client
+     * @var ClientInterface
      */
     private $client;
 
     /**
-     * @var Scope[]
+     * @var ScopeInterface[]
      */
     private $scopes = [];
 
@@ -41,7 +41,7 @@ class AccessToken
     public function __construct(
         string $identifier,
         DateTimeInterface $expiry,
-        Client $client,
+        ClientInterface $client,
         ?string $userIdentifier,
         array $scopes
     ) {
@@ -72,7 +72,7 @@ class AccessToken
         return $this->userIdentifier;
     }
 
-    public function getClient(): Client
+    public function getClient(): ClientInterface
     {
         return $this->client;
     }
@@ -90,7 +90,7 @@ class AccessToken
         return $this->revoked;
     }
 
-    public function revoke(): self
+    public function revoke(): AccessTokenInterface
     {
         $this->revoked = true;
 

--- a/Model/AccessTokenInterface.php
+++ b/Model/AccessTokenInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Model;
+
+use DateTimeInterface;
+
+interface AccessTokenInterface
+{
+    public function __toString(): string;
+
+    public function getIdentifier(): string;
+
+    public function getExpiry(): DateTimeInterface;
+
+    public function getUserIdentifier(): ?string;
+
+    public function getClient(): ClientInterface;
+
+    public function getScopes(): array;
+
+    public function isRevoked(): bool;
+
+    public function revoke(): self;
+}

--- a/Model/AuthorizationCode.php
+++ b/Model/AuthorizationCode.php
@@ -6,7 +6,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Model;
 
 use DateTimeInterface;
 
-class AuthorizationCode
+class AuthorizationCode implements AuthorizationCodeInterface
 {
     /**
      * @var string
@@ -24,12 +24,12 @@ class AuthorizationCode
     private $userIdentifier;
 
     /**
-     * @var Client
+     * @var ClientInterface
      */
     private $client;
 
     /**
-     * @var Scope[]
+     * @var ScopeInterface[]
      */
     private $scopes = [];
 
@@ -41,7 +41,7 @@ class AuthorizationCode
     public function __construct(
         string $identifier,
         DateTimeInterface $expiry,
-        Client $client,
+        ClientInterface $client,
         ?string $userIdentifier,
         array $scopes)
     {
@@ -72,7 +72,7 @@ class AuthorizationCode
         return $this->userIdentifier;
     }
 
-    public function getClient(): Client
+    public function getClient(): ClientInterface
     {
         return $this->client;
     }
@@ -90,7 +90,7 @@ class AuthorizationCode
         return $this->revoked;
     }
 
-    public function revoke(): self
+    public function revoke(): AuthorizationCodeInterface
     {
         $this->revoked = true;
 

--- a/Model/AuthorizationCodeInterface.php
+++ b/Model/AuthorizationCodeInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Model;
+
+use DateTimeInterface;
+
+interface AuthorizationCodeInterface
+{
+    public function __toString(): string;
+
+    public function getIdentifier(): string;
+
+    public function getExpiryDateTime(): DateTimeInterface;
+
+    public function getUserIdentifier(): ?string;
+
+    public function getClient(): ClientInterface;
+
+    public function getScopes(): array;
+
+    public function isRevoked(): bool;
+
+    public function revoke(): self;
+}

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Model;
 
-class Client
+class Client implements ClientInterface
 {
     /**
      * @var string
@@ -17,17 +17,17 @@ class Client
     private $secret;
 
     /**
-     * @var RedirectUri[]
+     * @var RedirectUriInterface[]
      */
     private $redirectUris = [];
 
     /**
-     * @var Grant[]
+     * @var GrantInterface[]
      */
     private $grants = [];
 
     /**
-     * @var Scope[]
+     * @var ScopeInterface[]
      */
     private $scopes = [];
 
@@ -62,7 +62,7 @@ class Client
         return $this->secret;
     }
 
-    public function setSecret(?string $secret): self
+    public function setSecret(?string $secret): ClientInterface
     {
         $this->secret = $secret;
 
@@ -70,14 +70,14 @@ class Client
     }
 
     /**
-     * @return RedirectUri[]
+     * @return RedirectUriInterface[]
      */
     public function getRedirectUris(): array
     {
         return $this->redirectUris;
     }
 
-    public function setRedirectUris(RedirectUri ...$redirectUris): self
+    public function setRedirectUris(RedirectUriInterface ...$redirectUris): ClientInterface
     {
         $this->redirectUris = $redirectUris;
 
@@ -85,14 +85,14 @@ class Client
     }
 
     /**
-     * @return Grant[]
+     * @return GrantInterface[]
      */
     public function getGrants(): array
     {
         return $this->grants;
     }
 
-    public function setGrants(Grant ...$grants): self
+    public function setGrants(GrantInterface ...$grants): ClientInterface
     {
         $this->grants = $grants;
 
@@ -100,14 +100,14 @@ class Client
     }
 
     /**
-     * @return Scope[]
+     * @return ScopeInterface[]
      */
     public function getScopes(): array
     {
         return $this->scopes;
     }
 
-    public function setScopes(Scope ...$scopes): self
+    public function setScopes(ScopeInterface ...$scopes): ClientInterface
     {
         $this->scopes = $scopes;
 
@@ -119,7 +119,7 @@ class Client
         return $this->active;
     }
 
-    public function setActive(bool $active): self
+    public function setActive(bool $active): ClientInterface
     {
         $this->active = $active;
 
@@ -136,7 +136,7 @@ class Client
         return $this->allowPlainTextPkce;
     }
 
-    public function setAllowPlainTextPkce(bool $allowPlainTextPkce): self
+    public function setAllowPlainTextPkce(bool $allowPlainTextPkce): ClientInterface
     {
         $this->allowPlainTextPkce = $allowPlainTextPkce;
 

--- a/Model/ClientInterface.php
+++ b/Model/ClientInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Model;
+
+interface ClientInterface
+{
+    public function __toString(): string;
+
+    public function getIdentifier(): string;
+
+    public function getSecret(): ?string;
+
+    public function setSecret(?string $secret): self;
+
+    public function getRedirectUris(): array;
+
+    public function setRedirectUris(RedirectUriInterface ...$redirectUris): self;
+
+    public function getGrants(): array;
+
+    public function setGrants(GrantInterface ...$grants): self;
+
+    public function getScopes(): array;
+
+    public function setScopes(ScopeInterface ...$scopes): self;
+
+    public function isActive(): bool;
+
+    public function setActive(bool $active): self;
+
+    public function isConfidential(): bool;
+
+    public function isPlainTextPkceAllowed(): bool;
+
+    public function setAllowPlainTextPkce(bool $allowPlainTextPkce): self;
+}

--- a/Model/Grant.php
+++ b/Model/Grant.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Model;
 
-class Grant
+class Grant implements GrantInterface
 {
     /**
      * @var string

--- a/Model/GrantInterface.php
+++ b/Model/GrantInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Model;
+
+interface GrantInterface
+{
+    public function __toString(): string;
+}

--- a/Model/RedirectUri.php
+++ b/Model/RedirectUri.php
@@ -6,7 +6,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Model;
 
 use RuntimeException;
 
-class RedirectUri
+class RedirectUri implements RedirectUriInterface
 {
     /**
      * @var string

--- a/Model/RedirectUriInterface.php
+++ b/Model/RedirectUriInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Model;
+
+interface RedirectUriInterface
+{
+    public function __toString(): string;
+}

--- a/Model/RefreshToken.php
+++ b/Model/RefreshToken.php
@@ -6,7 +6,7 @@ namespace Trikoder\Bundle\OAuth2Bundle\Model;
 
 use DateTimeInterface;
 
-class RefreshToken
+class RefreshToken implements RefreshTokenInterface
 {
     /**
      * @var string
@@ -50,7 +50,7 @@ class RefreshToken
         return $this->expiry;
     }
 
-    public function getAccessToken(): ?AccessToken
+    public function getAccessToken(): ?AccessTokenInterface
     {
         return $this->accessToken;
     }
@@ -60,7 +60,7 @@ class RefreshToken
         return $this->revoked;
     }
 
-    public function revoke(): self
+    public function revoke(): RefreshTokenInterface
     {
         $this->revoked = true;
 

--- a/Model/RefreshTokenInterface.php
+++ b/Model/RefreshTokenInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Model;
+
+use DateTimeInterface;
+
+interface RefreshTokenInterface
+{
+    public function __toString(): string;
+
+    public function getIdentifier(): string;
+
+    public function getExpiry(): DateTimeInterface;
+
+    public function getAccessToken(): ?AccessTokenInterface;
+
+    public function isRevoked(): bool;
+
+    public function revoke(): self;
+}

--- a/Model/Scope.php
+++ b/Model/Scope.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Model;
 
-class Scope
+class Scope implements ScopeInterface
 {
     /**
      * @var string

--- a/Model/ScopeInterface.php
+++ b/Model/ScopeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Model;
+
+interface ScopeInterface
+{
+    public function __toString(): string;
+}

--- a/Service/ClientFinderInterface.php
+++ b/Service/ClientFinderInterface.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Service;
 
-use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\Model\ClientInterface;
 
 /**
  * @api
  */
 interface ClientFinderInterface
 {
-    public function find(string $identifier): ?Client;
+    public function find(string $identifier): ?ClientInterface;
 }


### PR DESCRIPTION
I stumbled upon this problem recently where I needed to override doctrine mappings with my custom mappings and models as well thus override some manager classes to use my models. While doing this I realized that manager interfaces are dependant on concrete classes rather than abstractions. This change should bring more flexibility and freedom when overriding default managers with custom models.