### PR TITLE
Rely on AjgarlagPsrHttpMessageBundle for bridging HttpFoundation and PSR-7

### DIFF
--- a/DependencyInjection/TrikoderOAuth2Extension.php
+++ b/DependencyInjection/TrikoderOAuth2Extension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\DependencyInjection;
 
+use Ajgarlag\Bundle\PsrHttpMessageBundle\AjgarlagPsrHttpMessageBundle;
 use DateInterval;
 use Defuse\Crypto\Key;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
@@ -18,7 +19,6 @@ use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\ResourceServer;
 use LogicException;
 use RuntimeException;
-use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -115,7 +115,7 @@ final class TrikoderOAuth2Extension extends Extension implements PrependExtensio
         $requiredBundles = [
             'doctrine' => DoctrineBundle::class,
             'security' => SecurityBundle::class,
-            'sensio_framework_extra' => SensioFrameworkExtraBundle::class,
+            'ajgarlag_psr_http_message' => AjgarlagPsrHttpMessageBundle::class,
         ];
 
         foreach ($requiredBundles as $bundleAlias => $requiredBundle) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -83,7 +83,7 @@
         <service id="Trikoder\Bundle\OAuth2Bundle\Security\Firewall\OAuth2Listener">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authentication.manager" />
-            <argument type="service" id="sensio_framework_extra.psr7.http_message_factory" />
+            <argument type="service" id="Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface" />
             <argument key="$oauth2TokenFactory" type="service" id="Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory" />
         </service>
         <service id="trikoder.oauth2.security.firewall.oauth2_listener" alias="Trikoder\Bundle\OAuth2Bundle\Security\Firewall\OAuth2Listener">
@@ -96,7 +96,7 @@
 
         <!-- Guard Security Layer-->
         <service id="Trikoder\Bundle\OAuth2Bundle\Security\Guard\Authenticator\OAuth2Authenticator">
-            <argument type="service" id="sensio_framework_extra.psr7.http_message_factory" />
+            <argument type="service" id="Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface" />
             <argument type="service" id="League\OAuth2\Server\ResourceServer" />
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory" />
         </service>

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -63,6 +63,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
     {
         return [
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Ajgarlag\Bundle\PsrHttpMessageBundle\AjgarlagPsrHttpMessageBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\SecurityBundle\SecurityBundle(),

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -64,7 +64,6 @@ final class TestKernel extends Kernel implements CompilerPassInterface
         return [
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new \Ajgarlag\Bundle\PsrHttpMessageBundle\AjgarlagPsrHttpMessageBundle(),
-            new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new \Trikoder\Bundle\OAuth2Bundle\TrikoderOAuth2Bundle(),
@@ -195,12 +194,6 @@ final class TestKernel extends Kernel implements CompilerPassInterface
         $container->loadFromExtension('ajgarlag_psr_http_message', [
             'alias_sensio_framework_extra_services' => [
                 'enabled' => true,
-            ],
-        ]);
-
-        $container->loadFromExtension('sensio_framework_extra', [
-            'router' => [
-                'annotations' => false,
             ],
         ]);
 

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -192,6 +192,12 @@ final class TestKernel extends Kernel implements CompilerPassInterface
             ],
         ]);
 
+        $container->loadFromExtension('ajgarlag_psr_http_message', [
+            'alias_sensio_framework_extra_services' => [
+                'enabled' => true,
+            ],
+        ]);
+
         $container->loadFromExtension('sensio_framework_extra', [
             'router' => [
                 'annotations' => false,

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -191,12 +191,6 @@ final class TestKernel extends Kernel implements CompilerPassInterface
             ],
         ]);
 
-        $container->loadFromExtension('ajgarlag_psr_http_message', [
-            'alias_sensio_framework_extra_services' => [
-                'enabled' => true,
-            ],
-        ]);
-
         $container->loadFromExtension('trikoder_oauth2', [
             'authorization_server' => [
                 'private_key' => '%env(PRIVATE_KEY_PATH)%',

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": ">=7.2",
+        "ajgarlag/psr-http-message-bundle": "^1.1",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.7",
         "league/oauth2-server": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "doctrine/orm": "^2.7",
         "league/oauth2-server": "^8.0",
         "psr/http-factory": "^1.0",
-        "sensio/framework-extra-bundle": "^5.5",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/psr-http-message-bridge": "^2.0",
         "symfony/security-bundle": "^4.4|^5.0"


### PR DESCRIPTION
I've released a small bundle ([`ajgarlag/psr-http-message-bundle`](https://github.com/ajgarlag/psr-http-message-bundle)) to provide the [PSR-7 Support feature removed](https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/710) from `sensio/framework-extra-bundle:>=6.0`.

This PR requires `ajgarlag/psr-http-message-bundle` and remove `sensio/framework-extra-bundle` dependency.

Any feedback is welcome.

Fix #261 