### PR TITLE
Allow custom uris for mobile app like com.example.test123:/uri/redire…

### DIFF
--- a/Model/RedirectUri.php
+++ b/Model/RedirectUri.php
@@ -15,11 +15,57 @@ class RedirectUri
 
     public function __construct(string $redirectUri)
     {
-        if (!preg_match('/((https?):\/\/|www\.|[-\w\.]{1,}:\/)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|]/', $redirectUri)) {
-            throw new RuntimeException(sprintf('The \'%s\' string is not a valid URI.', $redirectUri));
-        }
+        $this->assertValidRedirectUri($redirectUri);
 
         $this->redirectUri = $redirectUri;
+    }
+
+    private function assertValidRedirectUri(string $redirectUri): void
+    {
+        if (filter_var($redirectUri, FILTER_VALIDATE_URL)) {
+            return;
+        }
+
+        if ($this->isValidCustomURIScheme($redirectUri)) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf('The \'%s\' string is not a valid URI.', $redirectUri));
+    }
+
+    /**
+     * @see https://developers.google.com/identity/protocols/oauth2/native-app?hl=en
+     */
+    private function isValidCustomURIScheme(string $redirectUri): bool
+    {
+        $parts = parse_url($redirectUri);
+        if (isset($parts['host'])) {
+            return false;
+        }
+        if (!isset($parts['scheme'])) {
+            return false;
+        }
+
+        //Deny if scheme start or end by "."
+        if ('.' === substr($parts['scheme'], 0, 1) || '.' === substr($parts['scheme'], -1, 1)) {
+            return false;
+        }
+
+        //Deny if scheme doesn't have "." domain separator
+        if (false === strpos(substr($parts['scheme'], 1, -1), '.')) {
+            return false;
+        }
+
+        if (isset($parts['path'])) {
+            if ('/' !== $parts['path'][0]) {
+                return false;
+            }
+            if (1 < \strlen($parts['path']) && '/' === $parts['path'][1]) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function __toString(): string

--- a/Model/RedirectUri.php
+++ b/Model/RedirectUri.php
@@ -15,7 +15,7 @@ class RedirectUri
 
     public function __construct(string $redirectUri)
     {
-        if (!preg_match('/\b(?:(?:https?|ftp):\/\/|www\.)?[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|]/', $redirectUri)) {
+        if (!preg_match('/((https?):\/\/|www\.|[-\w\.]{1,}:\/)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|]/', $redirectUri)) {
             throw new RuntimeException(sprintf('The \'%s\' string is not a valid URI.', $redirectUri));
         }
 

--- a/Model/RedirectUri.php
+++ b/Model/RedirectUri.php
@@ -15,7 +15,7 @@ class RedirectUri
 
     public function __construct(string $redirectUri)
     {
-        if (!filter_var($redirectUri, FILTER_VALIDATE_URL)) {
+        if (!preg_match('/\b(?:(?:https?|ftp):\/\/|www\.)?[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|]/', $redirectUri)) {
             throw new RuntimeException(sprintf('The \'%s\' string is not a valid URI.', $redirectUri));
         }
 

--- a/Tests/Model/RedirectUriTest.php
+++ b/Tests/Model/RedirectUriTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Model;
 
-use \RuntimeException;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri;
 
 class RedirectUriTest extends TestCase
 {
-
     public function testUris()
     {
         $passingUris = [

--- a/Tests/Model/RedirectUriTest.php
+++ b/Tests/Model/RedirectUriTest.php
@@ -17,19 +17,19 @@ class RedirectUriTest extends TestCase
             'http://www.oauth2.com/redirect/to-uri',
             'https://oauth2.com/redirect-to-uri',
             'com.example.test123:/redirect/to-uri',
-            'com.example.test:/redirect-to-uri'
+            'com.example.test:/redirect-to-uri',
         ];
 
         $faillingUris = [
             'someRandomString',
         ];
 
-        foreach($passingUris as $uri) {
+        foreach ($passingUris as $uri) {
             $redirectUri = new RedirectUri($uri);
             $this->assertInstanceOf(RedirectUri::class, $redirectUri);
         }
 
-        foreach($faillingUris as $uri) {
+        foreach ($faillingUris as $uri) {
             $this->expectException(RuntimeException::class);
             $redirectUri = new RedirectUri($uri);
         }

--- a/Tests/Model/RedirectUriTest.php
+++ b/Tests/Model/RedirectUriTest.php
@@ -10,27 +10,44 @@ use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri;
 
 class RedirectUriTest extends TestCase
 {
-    public function testUris()
+    public function testPassingUris()
     {
         $passingUris = [
             'http://www.oauth2.com/redirect/to-uri',
             'https://oauth2.com/redirect-to-uri',
             'com.example.test123:/redirect/to-uri',
             'com.example.test:/redirect-to-uri',
-        ];
-
-        $faillingUris = [
-            'someRandomString',
+            'com.example.test:',
+            'http://www.oauth2.com',
         ];
 
         foreach ($passingUris as $uri) {
             $redirectUri = new RedirectUri($uri);
             $this->assertInstanceOf(RedirectUri::class, $redirectUri);
         }
+    }
 
-        foreach ($faillingUris as $uri) {
-            $this->expectException(RuntimeException::class);
-            $redirectUri = new RedirectUri($uri);
-        }
+    public function testFailingUri1()
+    {
+        $this->expectException(RuntimeException::class);
+        $redirectUri = new RedirectUri('comexampletest:/redirect/to-uri');
+    }
+
+    public function testFailingUri2()
+    {
+        $this->expectException(RuntimeException::class);
+        $redirectUri = new RedirectUri('someRandomString');
+    }
+
+    public function testFailingUri3()
+    {
+        $this->expectException(RuntimeException::class);
+        $redirectUri = new RedirectUri('.com.example.test:/redirect/to-uri');
+    }
+
+    public function testFailingUri4()
+    {
+        $this->expectException(RuntimeException::class);
+        $redirectUri = new RedirectUri('com.example.test.:/redirect/to-uri');
     }
 }

--- a/Tests/Model/RedirectUriTest.php
+++ b/Tests/Model/RedirectUriTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Trikoder\Bundle\OAuth2Bundle\Tests\Model;
+
+use \RuntimeException;
+use PHPUnit\Framework\TestCase;
+use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri;
+
+class RedirectUriTest extends TestCase
+{
+
+    public function testUris()
+    {
+        $passingUris = [
+            'http://www.oauth2.com/redirect/to-uri',
+            'https://oauth2.com/redirect-to-uri',
+            'com.example.test123:/redirect/to-uri',
+            'com.example.test:/redirect-to-uri'
+        ];
+
+        $faillingUris = [
+            'someRandomString',
+        ];
+
+        foreach($passingUris as $uri) {
+            $redirectUri = new RedirectUri($uri);
+            $this->assertInstanceOf(RedirectUri::class, $redirectUri);
+        }
+
+        foreach($faillingUris as $uri) {
+            $this->expectException(RuntimeException::class);
+            $redirectUri = new RedirectUri($uri);
+        }
+    }
+}


### PR DESCRIPTION
As the redirect uri can be a url but also a custom uri path as described here https://developers.google.com/identity/protocols/oauth2/native-app#custom-uri-scheme

We can't only rely on the filter_var to check if the URI is valid. 
