### PR TITLE
Replace ext timecop with Carbon

### DIFF
--- a/League/Entity/Client.php
+++ b/League/Entity/Client.php
@@ -10,8 +10,8 @@ use League\OAuth2\Server\Entities\Traits\EntityTrait;
 
 final class Client implements ClientEntityInterface
 {
-    use EntityTrait;
     use ClientTrait;
+    use EntityTrait;
 
     /**
      * @var bool

--- a/Manager/Doctrine/AccessTokenManager.php
+++ b/Manager/Doctrine/AccessTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -43,7 +43,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
         return $this->entityManager->createQueryBuilder()
             ->delete(AccessToken::class, 'at')
             ->where('at.expiry < :expiry')
-            ->setParameter('expiry', new DateTimeImmutable())
+            ->setParameter('expiry', Chronos::now())
             ->getQuery()
             ->execute();
     }

--- a/Manager/Doctrine/AccessTokenManager.php
+++ b/Manager/Doctrine/AccessTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -43,7 +43,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
         return $this->entityManager->createQueryBuilder()
             ->delete(AccessToken::class, 'at')
             ->where('at.expiry < :expiry')
-            ->setParameter('expiry', Chronos::now())
+            ->setParameter('expiry', CarbonImmutable::now())
             ->getQuery()
             ->execute();
     }

--- a/Manager/Doctrine/AuthorizationCodeManager.php
+++ b/Manager/Doctrine/AuthorizationCodeManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -43,7 +43,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
         return $this->entityManager->createQueryBuilder()
             ->delete(AuthorizationCode::class, 'ac')
             ->where('ac.expiry < :expiry')
-            ->setParameter('expiry', new DateTimeImmutable())
+            ->setParameter('expiry', Chronos::now())
             ->getQuery()
             ->execute();
     }

--- a/Manager/Doctrine/AuthorizationCodeManager.php
+++ b/Manager/Doctrine/AuthorizationCodeManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -43,7 +43,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
         return $this->entityManager->createQueryBuilder()
             ->delete(AuthorizationCode::class, 'ac')
             ->where('ac.expiry < :expiry')
-            ->setParameter('expiry', Chronos::now())
+            ->setParameter('expiry', CarbonImmutable::now())
             ->getQuery()
             ->execute();
     }

--- a/Manager/Doctrine/RefreshTokenManager.php
+++ b/Manager/Doctrine/RefreshTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
@@ -43,7 +43,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
         return $this->entityManager->createQueryBuilder()
             ->delete(RefreshToken::class, 'rt')
             ->where('rt.expiry < :expiry')
-            ->setParameter('expiry', new DateTimeImmutable())
+            ->setParameter('expiry', new Chronos())
             ->getQuery()
             ->execute();
     }

--- a/Manager/Doctrine/RefreshTokenManager.php
+++ b/Manager/Doctrine/RefreshTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
@@ -43,7 +43,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
         return $this->entityManager->createQueryBuilder()
             ->delete(RefreshToken::class, 'rt')
             ->where('rt.expiry < :expiry')
-            ->setParameter('expiry', new Chronos())
+            ->setParameter('expiry', new CarbonImmutable())
             ->getQuery()
             ->execute();
     }

--- a/Manager/InMemory/AccessTokenManager.php
+++ b/Manager/InMemory/AccessTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 
@@ -35,7 +35,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
     {
         $count = \count($this->accessTokens);
 
-        $now = Chronos::now();
+        $now = CarbonImmutable::now();
         $this->accessTokens = array_filter($this->accessTokens, static function (AccessToken $accessToken) use ($now): bool {
             return $accessToken->getExpiry() >= $now;
         });

--- a/Manager/InMemory/AccessTokenManager.php
+++ b/Manager/InMemory/AccessTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 
@@ -35,7 +35,7 @@ final class AccessTokenManager implements AccessTokenManagerInterface
     {
         $count = \count($this->accessTokens);
 
-        $now = new DateTimeImmutable();
+        $now = Chronos::now();
         $this->accessTokens = array_filter($this->accessTokens, static function (AccessToken $accessToken) use ($now): bool {
             return $accessToken->getExpiry() >= $now;
         });

--- a/Manager/InMemory/AuthorizationCodeManager.php
+++ b/Manager/InMemory/AuthorizationCodeManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
 
@@ -29,7 +29,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
     {
         $count = \count($this->authorizationCodes);
 
-        $now = Chronos::now();
+        $now = CarbonImmutable::now();
         $this->authorizationCodes = array_filter($this->authorizationCodes, static function (AuthorizationCode $authorizationCode) use ($now): bool {
             return $authorizationCode->getExpiryDateTime() >= $now;
         });

--- a/Manager/InMemory/AuthorizationCodeManager.php
+++ b/Manager/InMemory/AuthorizationCodeManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
 
@@ -29,7 +29,7 @@ final class AuthorizationCodeManager implements AuthorizationCodeManagerInterfac
     {
         $count = \count($this->authorizationCodes);
 
-        $now = new DateTimeImmutable();
+        $now = Chronos::now();
         $this->authorizationCodes = array_filter($this->authorizationCodes, static function (AuthorizationCode $authorizationCode) use ($now): bool {
             return $authorizationCode->getExpiryDateTime() >= $now;
         });

--- a/Manager/InMemory/RefreshTokenManager.php
+++ b/Manager/InMemory/RefreshTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
 
@@ -35,7 +35,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
     {
         $count = \count($this->refreshTokens);
 
-        $now = new DateTimeImmutable();
+        $now = new Chronos();
         $this->refreshTokens = array_filter($this->refreshTokens, static function (RefreshToken $refreshToken) use ($now): bool {
             return $refreshToken->getExpiry() >= $now;
         });

--- a/Manager/InMemory/RefreshTokenManager.php
+++ b/Manager/InMemory/RefreshTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Manager\InMemory;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Manager\RefreshTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
 
@@ -35,7 +35,7 @@ final class RefreshTokenManager implements RefreshTokenManagerInterface
     {
         $count = \count($this->refreshTokens);
 
-        $now = new Chronos();
+        $now = new CarbonImmutable();
         $this->refreshTokens = array_filter($this->refreshTokens, static function (RefreshToken $refreshToken) use ($now): bool {
             return $refreshToken->getExpiry() >= $now;
         });

--- a/Model/RedirectUri.php
+++ b/Model/RedirectUri.php
@@ -22,7 +22,7 @@ class RedirectUri
 
     private function assertValidRedirectUri(string $redirectUri): void
     {
-        if (filter_var($redirectUri, FILTER_VALIDATE_URL)) {
+        if (filter_var($redirectUri, \FILTER_VALIDATE_URL)) {
             return;
         }
 

--- a/Tests/Acceptance/AuthorizationEndpointTest.php
+++ b/Tests/Acceptance/AuthorizationEndpointTest.php
@@ -28,6 +28,8 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
     {
         parent::setUp();
 
+        Chronos::setTestNow(Chronos::now());
+
         FixtureFactory::initializeFixtures(
             $this->client->getContainer()->get(ScopeManagerInterface::class),
             $this->client->getContainer()->get(ClientManagerInterface::class),
@@ -55,21 +57,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -107,24 +103,18 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => $state,
-                    'code_challenge' => $codeChallenge,
-                    'code_challenge_method' => $codeChallengeMethod,
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => $state,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -165,22 +155,16 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $this->fail('This event should not have been dispatched.');
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => bin2hex(random_bytes(20)),
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => bin2hex(random_bytes(20)),
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -209,24 +193,18 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $this->fail('This event should not have been dispatched.');
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => $state,
-                    'code_challenge' => $codeChallenge,
-                    'code_challenge_method' => $codeChallengeMethod,
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => $state,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -259,24 +237,18 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_ALLOWED_TO_USE_PLAIN_CHALLENGE_METHOD,
-                    'response_type' => 'code',
-                    'scope' => '',
-                    'state' => $state,
-                    'code_challenge' => $codeChallenge,
-                    'code_challenge_method' => $codeChallengeMethod,
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_ALLOWED_TO_USE_PLAIN_CHALLENGE_METHOD,
+                'response_type' => 'code',
+                'scope' => '',
+                'state' => $state,
+                'code_challenge' => $codeChallenge,
+                'code_challenge_method' => $codeChallengeMethod,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -317,21 +289,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'token',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'token',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -358,23 +324,17 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->setResponse($response);
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                    'redirect_uri' => FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI,
-                    'scope' => FixtureFactory::FIXTURE_SCOPE_FIRST . ' ' . FixtureFactory::FIXTURE_SCOPE_SECOND,
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+                'redirect_uri' => FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI,
+                'scope' => FixtureFactory::FIXTURE_SCOPE_FIRST . ' ' . FixtureFactory::FIXTURE_SCOPE_SECOND,
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -396,21 +356,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
             $event->setResponse($response);
         }, 200);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -432,21 +386,15 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
             $event->setResponse($response);
         }, 100);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+            ]
+        );
 
         $response = $this->client->getResponse();
 
@@ -470,22 +418,16 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request(
-                'GET',
-                '/authorize',
-                [
-                    'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
-                    'response_type' => 'code',
-                    'state' => 'foobar',
-                    'redirect_uri' => 'https://example.org/oauth2/malicious-uri',
-                ]
-            );
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request(
+            'GET',
+            '/authorize',
+            [
+                'client_id' => FixtureFactory::FIXTURE_CLIENT_FIRST,
+                'response_type' => 'code',
+                'state' => 'foobar',
+                'redirect_uri' => 'https://example.org/oauth2/malicious-uri',
+            ]
+        );
 
         $response = $this->client->getResponse();
 

--- a/Tests/Acceptance/AuthorizationEndpointTest.php
+++ b/Tests/Acceptance/AuthorizationEndpointTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEvent;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
@@ -55,7 +55,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -68,7 +68,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -107,7 +107,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -123,7 +123,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -165,7 +165,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $this->fail('This event should not have been dispatched.');
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -179,7 +179,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -209,7 +209,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $this->fail('This event should not have been dispatched.');
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -225,7 +225,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -259,7 +259,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -275,7 +275,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -317,7 +317,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -330,7 +330,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -358,7 +358,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->setResponse($response);
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -373,7 +373,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -396,7 +396,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
             $event->setResponse($response);
         }, 200);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -409,7 +409,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -432,7 +432,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
             $event->setResponse($response);
         }, 100);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -445,7 +445,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -470,7 +470,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request(
@@ -484,7 +484,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
                 ]
             );
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();

--- a/Tests/Acceptance/AuthorizationEndpointTest.php
+++ b/Tests/Acceptance/AuthorizationEndpointTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEvent;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
@@ -28,7 +28,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
     {
         parent::setUp();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         FixtureFactory::initializeFixtures(
             $this->client->getContainer()->get(ScopeManagerInterface::class),
@@ -74,7 +74,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         $this->assertStringStartsWith(FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI, $redirectUri);
         $query = [];
-        parse_str(parse_url($redirectUri, PHP_URL_QUERY), $query);
+        parse_str(parse_url($redirectUri, \PHP_URL_QUERY), $query);
         $this->assertArrayHasKey('code', $query);
         $this->assertArrayHasKey('state', $query);
         $this->assertEquals('foobar', $query['state']);
@@ -123,7 +123,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         $this->assertStringStartsWith(FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI, $redirectUri);
         $query = [];
-        parse_str(parse_url($redirectUri, PHP_URL_QUERY), $query);
+        parse_str(parse_url($redirectUri, \PHP_URL_QUERY), $query);
         $this->assertArrayHasKey('state', $query);
         $this->assertSame($state, $query['state']);
 
@@ -257,7 +257,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         $this->assertStringStartsWith(FixtureFactory::FIXTURE_PUBLIC_CLIENT_ALLOWED_TO_USE_PLAIN_CHALLENGE_METHOD_REDIRECT_URI, $redirectUri);
         $query = [];
-        parse_str(parse_url($redirectUri, PHP_URL_QUERY), $query);
+        parse_str(parse_url($redirectUri, \PHP_URL_QUERY), $query);
         $this->assertArrayHasKey('state', $query);
         $this->assertSame($state, $query['state']);
 
@@ -306,7 +306,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         $this->assertStringStartsWith(FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI, $redirectUri);
         $fragment = [];
-        parse_str(parse_url($redirectUri, PHP_URL_FRAGMENT), $fragment);
+        parse_str(parse_url($redirectUri, \PHP_URL_FRAGMENT), $fragment);
         $this->assertArrayHasKey('access_token', $fragment);
         $this->assertArrayHasKey('token_type', $fragment);
         $this->assertArrayHasKey('expires_in', $fragment);
@@ -403,7 +403,7 @@ final class AuthorizationEndpointTest extends AbstractAcceptanceTest
 
         $this->assertStringStartsWith(FixtureFactory::FIXTURE_CLIENT_FIRST_REDIRECT_URI, $redirectUri);
         $query = [];
-        parse_str(parse_url($redirectUri, PHP_URL_QUERY), $query);
+        parse_str(parse_url($redirectUri, \PHP_URL_QUERY), $query);
         $this->assertArrayHasKey('code', $query);
         $this->assertArrayHasKey('state', $query);
         $this->assertEquals('foobar', $query['state']);

--- a/Tests/Acceptance/ClearExpiredTokensCommandTest.php
+++ b/Tests/Acceptance/ClearExpiredTokensCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -24,7 +24,7 @@ final class ClearExpiredTokensCommandTest extends AbstractAcceptanceTest
     {
         parent::setUp();
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         FixtureFactory::initializeFixtures(
             $this->client->getContainer()->get(ScopeManagerInterface::class),
@@ -37,7 +37,7 @@ final class ClearExpiredTokensCommandTest extends AbstractAcceptanceTest
 
     protected function tearDown(): void
     {
-        timecop_return();
+        Chronos::setTestNow(null);
 
         parent::tearDown();
     }

--- a/Tests/Acceptance/ClearExpiredTokensCommandTest.php
+++ b/Tests/Acceptance/ClearExpiredTokensCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -24,7 +24,7 @@ final class ClearExpiredTokensCommandTest extends AbstractAcceptanceTest
     {
         parent::setUp();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         FixtureFactory::initializeFixtures(
             $this->client->getContainer()->get(ScopeManagerInterface::class),
@@ -37,7 +37,7 @@ final class ClearExpiredTokensCommandTest extends AbstractAcceptanceTest
 
     protected function tearDown(): void
     {
-        Chronos::setTestNow(null);
+        CarbonImmutable::setTestNow(null);
 
         parent::tearDown();
     }

--- a/Tests/Acceptance/DoctrineAccessTokenManagerTest.php
+++ b/Tests/Acceptance/DoctrineAccessTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager as DoctrineAccessTokenManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -28,7 +28,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         try {
             $testData = $this->buildClearExpiredTestData($client);
@@ -40,7 +40,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
         } finally {
-            Chronos::setTestNow(null);
+            CarbonImmutable::setTestNow(null);
         }
 
         $this->assertSame(
@@ -119,7 +119,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
     {
         $accessToken = new AccessToken(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             $client,
             null,
             []
@@ -142,7 +142,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         try {
             $testData = $this->buildClearExpiredTestDataWithRefreshToken($client);
@@ -157,7 +157,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
         } finally {
-            Chronos::setTestNow(null);
+            CarbonImmutable::setTestNow(null);
         }
 
         $this->assertSame(
@@ -240,14 +240,14 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
     {
         $accessToken = new AccessToken(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             $client,
             null,
             []
         );
         $refreshToken = new RefreshToken(
             $identifier,
-            new Chronos('+1 day'),
+            new CarbonImmutable('+1 day'),
             $accessToken
         );
 

--- a/Tests/Acceptance/DoctrineAccessTokenManagerTest.php
+++ b/Tests/Acceptance/DoctrineAccessTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager as DoctrineAccessTokenManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -28,7 +28,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $testData = $this->buildClearExpiredTestData($client);
@@ -40,7 +40,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $this->assertSame(
@@ -119,7 +119,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
     {
         $accessToken = new AccessToken(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             $client,
             null,
             []
@@ -142,7 +142,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $testData = $this->buildClearExpiredTestDataWithRefreshToken($client);
@@ -157,7 +157,7 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineAccessTokenManager->clearExpired());
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $this->assertSame(
@@ -240,14 +240,14 @@ final class DoctrineAccessTokenManagerTest extends AbstractAcceptanceTest
     {
         $accessToken = new AccessToken(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             $client,
             null,
             []
         );
         $refreshToken = new RefreshToken(
             $identifier,
-            new DateTimeImmutable('+1 day'),
+            new Chronos('+1 day'),
             $accessToken
         );
 

--- a/Tests/Acceptance/DoctrineAuthCodeManagerTest.php
+++ b/Tests/Acceptance/DoctrineAuthCodeManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AuthorizationCodeManager as DoctrineAuthCodeManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -26,7 +26,7 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
         $client = new Client('client', 'secret');
         $em->persist($client);
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         try {
             $testData = $this->buildClearExpiredTestData($client);
@@ -40,7 +40,7 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineAuthCodeManager->clearExpired());
         } finally {
-            Chronos::setTestNow(null);
+            CarbonImmutable::setTestNow(null);
         }
 
         $this->assertSame(
@@ -120,7 +120,7 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
     {
         $authorizationCode = new AuthorizationCode(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             $client,
             null,
             []

--- a/Tests/Acceptance/DoctrineAuthCodeManagerTest.php
+++ b/Tests/Acceptance/DoctrineAuthCodeManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AuthorizationCodeManager as DoctrineAuthCodeManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -26,7 +26,7 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
         $client = new Client('client', 'secret');
         $em->persist($client);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $testData = $this->buildClearExpiredTestData($client);
@@ -40,7 +40,7 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineAuthCodeManager->clearExpired());
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $this->assertSame(
@@ -120,7 +120,7 @@ final class DoctrineAuthCodeManagerTest extends AbstractAcceptanceTest
     {
         $authorizationCode = new AuthorizationCode(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             $client,
             null,
             []

--- a/Tests/Acceptance/DoctrineClientManagerTest.php
+++ b/Tests/Acceptance/DoctrineClientManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager as DoctrineClientManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -46,7 +46,7 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        $accessToken = new AccessToken('access token', new DateTimeImmutable('+1 day'), $client, $client->getIdentifier(), []);
+        $accessToken = new AccessToken('access token', new Chronos('+1 day'), $client, $client->getIdentifier(), []);
         $em->persist($accessToken);
         $em->flush();
 
@@ -79,11 +79,11 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        $accessToken = new AccessToken('access token', new DateTimeImmutable('+1 day'), $client, $client->getIdentifier(), []);
+        $accessToken = new AccessToken('access token', new Chronos('+1 day'), $client, $client->getIdentifier(), []);
         $em->persist($accessToken);
         $em->flush();
 
-        $refreshToken = new RefreshToken('refresh token', new DateTimeImmutable('+1 day'), $accessToken);
+        $refreshToken = new RefreshToken('refresh token', new Chronos('+1 day'), $accessToken);
         $em->persist($refreshToken);
         $em->flush();
 

--- a/Tests/Acceptance/DoctrineClientManagerTest.php
+++ b/Tests/Acceptance/DoctrineClientManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager as DoctrineClientManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -46,7 +46,7 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        $accessToken = new AccessToken('access token', new Chronos('+1 day'), $client, $client->getIdentifier(), []);
+        $accessToken = new AccessToken('access token', new CarbonImmutable('+1 day'), $client, $client->getIdentifier(), []);
         $em->persist($accessToken);
         $em->flush();
 
@@ -79,11 +79,11 @@ final class DoctrineClientManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        $accessToken = new AccessToken('access token', new Chronos('+1 day'), $client, $client->getIdentifier(), []);
+        $accessToken = new AccessToken('access token', new CarbonImmutable('+1 day'), $client, $client->getIdentifier(), []);
         $em->persist($accessToken);
         $em->flush();
 
-        $refreshToken = new RefreshToken('refresh token', new Chronos('+1 day'), $accessToken);
+        $refreshToken = new RefreshToken('refresh token', new CarbonImmutable('+1 day'), $accessToken);
         $em->persist($refreshToken);
         $em->flush();
 

--- a/Tests/Acceptance/DoctrineCredentialsRevokerTest.php
+++ b/Tests/Acceptance/DoctrineCredentialsRevokerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -83,7 +83,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
     {
         return new RefreshToken(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             $accessToken
         );
     }
@@ -92,7 +92,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
     {
         return new AccessToken(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             $client,
             $userIdentifier,
             []
@@ -103,7 +103,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
     {
         return new AuthorizationCode(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             $client,
             $userIdentifier,
             []

--- a/Tests/Acceptance/DoctrineCredentialsRevokerTest.php
+++ b/Tests/Acceptance/DoctrineCredentialsRevokerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -83,7 +83,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
     {
         return new RefreshToken(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             $accessToken
         );
     }
@@ -92,7 +92,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
     {
         return new AccessToken(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             $client,
             $userIdentifier,
             []
@@ -103,7 +103,7 @@ final class DoctrineCredentialsRevokerTest extends AbstractAcceptanceTest
     {
         return new AuthorizationCode(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             $client,
             $userIdentifier,
             []

--- a/Tests/Acceptance/DoctrineRefreshTokenManagerTest.php
+++ b/Tests/Acceptance/DoctrineRefreshTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\RefreshTokenManager as DoctrineRefreshTokenManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -28,7 +28,7 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $testData = $this->buildClearExpiredTestData($client);
@@ -43,7 +43,7 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineRefreshTokenManager->clearExpired());
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $this->assertSame(
@@ -125,10 +125,10 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
     {
         $refreshToken = new RefreshToken(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             new AccessToken(
                 $identifier,
-                new DateTimeImmutable('+1 day'),
+                new Chronos('+1 day'),
                 $client,
                 null,
                 []

--- a/Tests/Acceptance/DoctrineRefreshTokenManagerTest.php
+++ b/Tests/Acceptance/DoctrineRefreshTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\RefreshTokenManager as DoctrineRefreshTokenManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
@@ -28,7 +28,7 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
         $em->persist($client);
         $em->flush();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         try {
             $testData = $this->buildClearExpiredTestData($client);
@@ -43,7 +43,7 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
 
             $this->assertSame(3, $doctrineRefreshTokenManager->clearExpired());
         } finally {
-            Chronos::setTestNow(null);
+            CarbonImmutable::setTestNow(null);
         }
 
         $this->assertSame(
@@ -125,10 +125,10 @@ final class DoctrineRefreshTokenManagerTest extends AbstractAcceptanceTest
     {
         $refreshToken = new RefreshToken(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             new AccessToken(
                 $identifier,
-                new Chronos('+1 day'),
+                new CarbonImmutable('+1 day'),
                 $client,
                 null,
                 []

--- a/Tests/Acceptance/TokenEndpointTest.php
+++ b/Tests/Acceptance/TokenEndpointTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
@@ -20,7 +20,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
     {
         parent::setUp();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         FixtureFactory::initializeFixtures(
             $this->client->getContainer()->get(ScopeManagerInterface::class),
@@ -35,7 +35,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
     {
         parent::tearDown();
 
-        Chronos::setTestNow(null);
+        CarbonImmutable::setTestNow(null);
     }
 
     public function testSuccessfulClientCredentialsRequest(): void

--- a/Tests/Acceptance/TokenEndpointTest.php
+++ b/Tests/Acceptance/TokenEndpointTest.php
@@ -54,7 +54,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $jsonResponse = json_decode($response->getContent(), true);
 
         $this->assertSame('Bearer', $jsonResponse['token_type']);
-        $this->assertSame(3600, $jsonResponse['expires_in']);
+        $this->assertEqualsWithDelta(3600, $jsonResponse['expires_in'], 2);
         $this->assertNotEmpty($jsonResponse['access_token']);
     }
 
@@ -83,7 +83,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $jsonResponse = json_decode($response->getContent(), true);
 
         $this->assertSame('Bearer', $jsonResponse['token_type']);
-        $this->assertSame(3600, $jsonResponse['expires_in']);
+        $this->assertEqualsWithDelta(3600, $jsonResponse['expires_in'], 2);
         $this->assertNotEmpty($jsonResponse['access_token']);
         $this->assertNotEmpty($jsonResponse['refresh_token']);
     }
@@ -110,7 +110,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $jsonResponse = json_decode($response->getContent(), true);
 
         $this->assertSame('Bearer', $jsonResponse['token_type']);
-        $this->assertSame(3600, $jsonResponse['expires_in']);
+        $this->assertEqualsWithDelta(3600, $jsonResponse['expires_in'], 2);
         $this->assertNotEmpty($jsonResponse['access_token']);
         $this->assertNotEmpty($jsonResponse['refresh_token']);
     }
@@ -138,7 +138,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $jsonResponse = json_decode($response->getContent(), true);
 
         $this->assertSame('Bearer', $jsonResponse['token_type']);
-        $this->assertSame(3600, $jsonResponse['expires_in']);
+        $this->assertEqualsWithDelta(3600, $jsonResponse['expires_in'], 2);
         $this->assertNotEmpty($jsonResponse['access_token']);
     }
 
@@ -164,7 +164,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         $jsonResponse = json_decode($response->getContent(), true);
 
         $this->assertSame('Bearer', $jsonResponse['token_type']);
-        $this->assertSame(3600, $jsonResponse['expires_in']);
+        $this->assertEqualsWithDelta(3600, $jsonResponse['expires_in'], 2);
         $this->assertNotEmpty($jsonResponse['access_token']);
     }
 

--- a/Tests/Acceptance/TokenEndpointTest.php
+++ b/Tests/Acceptance/TokenEndpointTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Acceptance;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
@@ -31,7 +31,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
 
     public function testSuccessfulClientCredentialsRequest(): void
     {
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request('POST', '/token', [
@@ -40,7 +40,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 'grant_type' => 'client_credentials',
             ]);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -64,7 +64,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 $event->setUser(FixtureFactory::createUser());
             });
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request('POST', '/token', [
@@ -75,7 +75,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 'password' => 'pass',
             ]);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -98,7 +98,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(RefreshTokenManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_REFRESH_TOKEN);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request('POST', '/token', [
@@ -108,7 +108,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 'refresh_token' => TestHelper::generateEncryptedPayload($refreshToken),
             ]);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -131,7 +131,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(AuthorizationCodeManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_AUTH_CODE);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request('POST', '/token', [
@@ -142,7 +142,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
             ]);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();
@@ -164,7 +164,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(AuthorizationCodeManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_AUTH_CODE_PUBLIC_CLIENT);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $this->client->request('POST', '/token', [
@@ -174,7 +174,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
             ]);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $response = $this->client->getResponse();

--- a/Tests/Acceptance/TokenEndpointTest.php
+++ b/Tests/Acceptance/TokenEndpointTest.php
@@ -20,6 +20,8 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
     {
         parent::setUp();
 
+        Chronos::setTestNow(Chronos::now());
+
         FixtureFactory::initializeFixtures(
             $this->client->getContainer()->get(ScopeManagerInterface::class),
             $this->client->getContainer()->get(ClientManagerInterface::class),
@@ -29,19 +31,20 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
         );
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Chronos::setTestNow(null);
+    }
+
     public function testSuccessfulClientCredentialsRequest(): void
     {
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'client_credentials',
-            ]);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'client_credentials',
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -64,19 +67,13 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
                 $event->setUser(FixtureFactory::createUser());
             });
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'password',
-                'username' => 'user',
-                'password' => 'pass',
-            ]);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'password',
+            'username' => 'user',
+            'password' => 'pass',
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -98,18 +95,12 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(RefreshTokenManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_REFRESH_TOKEN);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'refresh_token',
-                'refresh_token' => TestHelper::generateEncryptedPayload($refreshToken),
-            ]);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'refresh_token',
+            'refresh_token' => TestHelper::generateEncryptedPayload($refreshToken),
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -131,19 +122,13 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(AuthorizationCodeManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_AUTH_CODE);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => 'foo',
-                'client_secret' => 'secret',
-                'grant_type' => 'authorization_code',
-                'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
-                'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
-            ]);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => 'foo',
+            'client_secret' => 'secret',
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
+            'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
+        ]);
 
         $response = $this->client->getResponse();
 
@@ -164,18 +149,12 @@ final class TokenEndpointTest extends AbstractAcceptanceTest
             ->get(AuthorizationCodeManagerInterface::class)
             ->find(FixtureFactory::FIXTURE_AUTH_CODE_PUBLIC_CLIENT);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $this->client->request('POST', '/token', [
-                'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
-                'grant_type' => 'authorization_code',
-                'redirect_uri' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_REDIRECT_URI,
-                'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
-            ]);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $this->client->request('POST', '/token', [
+            'client_id' => FixtureFactory::FIXTURE_PUBLIC_CLIENT,
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => FixtureFactory::FIXTURE_PUBLIC_CLIENT_REDIRECT_URI,
+            'code' => TestHelper::generateEncryptedAuthCodePayload($authCode),
+        ]);
 
         $response = $this->client->getResponse();
 

--- a/Tests/Fixtures/FixtureFactory.php
+++ b/Tests/Fixtures/FixtureFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Fixtures;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
@@ -110,7 +110,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_USER_BOUND,
-            new Chronos('+1 hour'),
+            new CarbonImmutable('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -118,7 +118,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_DIFFERENT_CLIENT,
-            new Chronos('+1 hour'),
+            new CarbonImmutable('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_SECOND),
             self::FIXTURE_USER,
             []
@@ -126,7 +126,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_EXPIRED,
-            new Chronos('-1 hour'),
+            new CarbonImmutable('-1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -134,7 +134,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_REVOKED,
-            new Chronos('+1 hour'),
+            new CarbonImmutable('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -143,7 +143,7 @@ final class FixtureFactory
 
         $accessTokens[] = new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_PUBLIC,
-            new Chronos('+1 hour'),
+            new CarbonImmutable('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             null,
             []
@@ -151,7 +151,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_WITH_SCOPES,
-            new Chronos('+1 hour'),
+            new CarbonImmutable('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             null,
             [$scopeManager->find(self::FIXTURE_SCOPE_FIRST)]
@@ -159,7 +159,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_USER_BOUND_WITH_SCOPES,
-            new Chronos('+1 hour'),
+            new CarbonImmutable('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             [$scopeManager->find(self::FIXTURE_SCOPE_FIRST)]
@@ -177,32 +177,32 @@ final class FixtureFactory
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN,
-            new Chronos('+1 month'),
+            new CarbonImmutable('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_USER_BOUND)
         );
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_DIFFERENT_CLIENT,
-            new Chronos('+1 month'),
+            new CarbonImmutable('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_DIFFERENT_CLIENT)
         );
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_EXPIRED,
-            new Chronos('-1 month'),
+            new CarbonImmutable('-1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_EXPIRED)
         );
 
         $refreshTokens[] = (new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_REVOKED,
-            new Chronos('+1 month'),
+            new CarbonImmutable('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_REVOKED)
         ))
             ->revoke();
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_WITH_SCOPES,
-            new Chronos('+1 month'),
+            new CarbonImmutable('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_USER_BOUND_WITH_SCOPES)
         );
 
@@ -218,7 +218,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE,
-            new Chronos('+2 minute'),
+            new CarbonImmutable('+2 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -226,7 +226,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_PUBLIC_CLIENT,
-            new Chronos('+2 minute'),
+            new CarbonImmutable('+2 minute'),
             $clientManager->find(self::FIXTURE_PUBLIC_CLIENT),
             self::FIXTURE_USER,
             []
@@ -234,7 +234,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_DIFFERENT_CLIENT,
-            new Chronos('+2 minute'),
+            new CarbonImmutable('+2 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_SECOND),
             self::FIXTURE_USER,
             []
@@ -242,7 +242,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_EXPIRED,
-            new Chronos('-30 minute'),
+            new CarbonImmutable('-30 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -250,7 +250,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = (new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_REVOKED,
-            new Chronos('+5 minute'),
+            new CarbonImmutable('+5 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []

--- a/Tests/Fixtures/FixtureFactory.php
+++ b/Tests/Fixtures/FixtureFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Fixtures;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\AuthorizationCodeManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
@@ -110,7 +110,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_USER_BOUND,
-            new DateTimeImmutable('+1 hour'),
+            new Chronos('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -118,7 +118,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_DIFFERENT_CLIENT,
-            new DateTimeImmutable('+1 hour'),
+            new Chronos('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_SECOND),
             self::FIXTURE_USER,
             []
@@ -126,7 +126,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_EXPIRED,
-            new DateTimeImmutable('-1 hour'),
+            new Chronos('-1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -134,7 +134,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_REVOKED,
-            new DateTimeImmutable('+1 hour'),
+            new Chronos('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -143,7 +143,7 @@ final class FixtureFactory
 
         $accessTokens[] = new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_PUBLIC,
-            new DateTimeImmutable('+1 hour'),
+            new Chronos('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             null,
             []
@@ -151,7 +151,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_WITH_SCOPES,
-            new DateTimeImmutable('+1 hour'),
+            new Chronos('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             null,
             [$scopeManager->find(self::FIXTURE_SCOPE_FIRST)]
@@ -159,7 +159,7 @@ final class FixtureFactory
 
         $accessTokens[] = (new AccessToken(
             self::FIXTURE_ACCESS_TOKEN_USER_BOUND_WITH_SCOPES,
-            new DateTimeImmutable('+1 hour'),
+            new Chronos('+1 hour'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             [$scopeManager->find(self::FIXTURE_SCOPE_FIRST)]
@@ -177,32 +177,32 @@ final class FixtureFactory
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN,
-            new DateTimeImmutable('+1 month'),
+            new Chronos('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_USER_BOUND)
         );
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_DIFFERENT_CLIENT,
-            new DateTimeImmutable('+1 month'),
+            new Chronos('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_DIFFERENT_CLIENT)
         );
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_EXPIRED,
-            new DateTimeImmutable('-1 month'),
+            new Chronos('-1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_EXPIRED)
         );
 
         $refreshTokens[] = (new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_REVOKED,
-            new DateTimeImmutable('+1 month'),
+            new Chronos('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_REVOKED)
         ))
             ->revoke();
 
         $refreshTokens[] = new RefreshToken(
             self::FIXTURE_REFRESH_TOKEN_WITH_SCOPES,
-            new DateTimeImmutable('+1 month'),
+            new Chronos('+1 month'),
             $accessTokenManager->find(self::FIXTURE_ACCESS_TOKEN_USER_BOUND_WITH_SCOPES)
         );
 
@@ -218,7 +218,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE,
-            new DateTimeImmutable('+2 minute'),
+            new Chronos('+2 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -226,7 +226,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_PUBLIC_CLIENT,
-            new DateTimeImmutable('+2 minute'),
+            new Chronos('+2 minute'),
             $clientManager->find(self::FIXTURE_PUBLIC_CLIENT),
             self::FIXTURE_USER,
             []
@@ -234,7 +234,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_DIFFERENT_CLIENT,
-            new DateTimeImmutable('+2 minute'),
+            new Chronos('+2 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_SECOND),
             self::FIXTURE_USER,
             []
@@ -242,7 +242,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_EXPIRED,
-            new DateTimeImmutable('-30 minute'),
+            new Chronos('-30 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []
@@ -250,7 +250,7 @@ final class FixtureFactory
 
         $authorizationCodes[] = (new AuthorizationCode(
             self::FIXTURE_AUTH_CODE_REVOKED,
-            new DateTimeImmutable('+5 minute'),
+            new Chronos('+5 minute'),
             $clientManager->find(self::FIXTURE_CLIENT_FIRST),
             self::FIXTURE_USER,
             []

--- a/Tests/Integration/AuthCodeRepositoryTest.php
+++ b/Tests/Integration/AuthCodeRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Integration;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter;
 use Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -18,7 +18,7 @@ final class AuthCodeRepositoryTest extends AbstractIntegrationTest
 
         $authCode = new AuthorizationCode(
             $identifier,
-            new DateTimeImmutable(),
+            Chronos::now(),
             new Client('bar', 'baz'),
             null,
             []

--- a/Tests/Integration/AuthCodeRepositoryTest.php
+++ b/Tests/Integration/AuthCodeRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Integration;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter;
 use Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository;
 use Trikoder\Bundle\OAuth2Bundle\Model\AuthorizationCode;
@@ -18,7 +18,7 @@ final class AuthCodeRepositoryTest extends AbstractIntegrationTest
 
         $authCode = new AuthorizationCode(
             $identifier,
-            Chronos::now(),
+            CarbonImmutable::now(),
             new Client('bar', 'baz'),
             null,
             []

--- a/Tests/Integration/AuthorizationServerTest.php
+++ b/Tests/Integration/AuthorizationServerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Integration;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
@@ -17,7 +17,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
     {
         parent::setUp();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         FixtureFactory::initializeFixtures(
             $this->scopeManager,
@@ -32,7 +32,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
     {
         parent::tearDown();
 
-        Chronos::setTestNow(null);
+        CarbonImmutable::setTestNow(null);
     }
 
     public function testSuccessfulAuthorizationThroughHeaders(): void
@@ -722,7 +722,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
-        parse_str(parse_url($response->getHeaderLine('Location'), PHP_URL_FRAGMENT), $responseData);
+        parse_str(parse_url($response->getHeaderLine('Location'), \PHP_URL_FRAGMENT), $responseData);
         $accessToken = $this->getAccessToken($responseData['access_token']);
 
         // Response assertions.
@@ -744,7 +744,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
-        parse_str(parse_url($response->getHeaderLine('Location'), PHP_URL_FRAGMENT), $responseData);
+        parse_str(parse_url($response->getHeaderLine('Location'), \PHP_URL_FRAGMENT), $responseData);
         $accessToken = $this->getAccessToken($responseData['access_token']);
 
         // Response assertions.
@@ -767,7 +767,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
-        parse_str(parse_url($response->getHeaderLine('Location'), PHP_URL_FRAGMENT), $responseData);
+        parse_str(parse_url($response->getHeaderLine('Location'), \PHP_URL_FRAGMENT), $responseData);
         $accessToken = $this->getAccessToken($responseData['access_token']);
 
         // Response assertions.
@@ -788,7 +788,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
         $response = $this->handleAuthorizationRequest($request);
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
-        parse_str(parse_url($response->getHeaderLine('Location'), PHP_URL_QUERY), $responseData);
+        parse_str(parse_url($response->getHeaderLine('Location'), \PHP_URL_QUERY), $responseData);
 
         // Response assertions.
         $this->assertSame('invalid_scope', $responseData['error']);
@@ -823,7 +823,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
         $response = $this->handleAuthorizationRequest($request, false);
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
-        parse_str(parse_url($response->getHeaderLine('Location'), PHP_URL_QUERY), $responseData);
+        parse_str(parse_url($response->getHeaderLine('Location'), \PHP_URL_QUERY), $responseData);
 
         // Response assertions.
         $this->assertSame('access_denied', $responseData['error']);

--- a/Tests/Integration/AuthorizationServerTest.php
+++ b/Tests/Integration/AuthorizationServerTest.php
@@ -17,6 +17,8 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
     {
         parent::setUp();
 
+        Chronos::setTestNow(Chronos::now());
+
         FixtureFactory::initializeFixtures(
             $this->scopeManager,
             $this->clientManager,
@@ -24,6 +26,13 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             $this->refreshTokenManager,
             $this->authCodeManager
         );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Chronos::setTestNow(null);
     }
 
     public function testSuccessfulAuthorizationThroughHeaders(): void
@@ -168,13 +177,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'grant_type' => 'client_credentials',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
 
@@ -194,13 +197,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'scope' => 'fancy',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
 
@@ -227,13 +224,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'grant_type' => 'client_credentials',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
 
@@ -261,13 +252,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'scope' => 'rock',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
 
@@ -300,13 +285,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'password' => 'pass',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
         $refreshToken = $this->getRefreshToken($response['refresh_token']);
@@ -383,13 +362,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'refresh_token' => TestHelper::generateEncryptedPayload($existingRefreshToken),
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
         $refreshToken = $this->getRefreshToken($response['refresh_token']);
@@ -675,13 +648,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleTokenRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleTokenRequest($request);
 
         $accessToken = $this->getAccessToken($response['access_token']);
 
@@ -751,13 +718,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'client_id' => 'foo',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleAuthorizationRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleAuthorizationRequest($request);
 
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
@@ -779,13 +740,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'state' => 'quzbaz',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleAuthorizationRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleAuthorizationRequest($request);
 
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];
@@ -808,13 +763,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
         ]);
 
-        Chronos::setTestNow(Chronos::now());
-
-        try {
-            $response = $this->handleAuthorizationRequest($request);
-        } finally {
-            Chronos::setTestNow(null);
-        }
+        $response = $this->handleAuthorizationRequest($request);
 
         $this->assertSame(302, $response->getStatusCode());
         $responseData = [];

--- a/Tests/Integration/AuthorizationServerTest.php
+++ b/Tests/Integration/AuthorizationServerTest.php
@@ -183,7 +183,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $response['token_type']);
-        $this->assertSame(3600, $response['expires_in']);
+        $this->assertEqualsWithDelta(3600, $response['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
 
         // Make sure the access token is issued for the given client ID.
@@ -203,7 +203,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $response['token_type']);
-        $this->assertSame(3600, $response['expires_in']);
+        $this->assertEqualsWithDelta(3600, $response['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
 
         // Make sure the access token is issued for the given client ID.
@@ -230,7 +230,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $response['token_type']);
-        $this->assertSame(3600, $response['expires_in']);
+        $this->assertEqualsWithDelta(3600, $response['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
 
         // Make sure the access token is issued for the given client ID.
@@ -258,7 +258,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $response['token_type']);
-        $this->assertSame(3600, $response['expires_in']);
+        $this->assertEqualsWithDelta(3600, $response['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
 
         // Make sure the access token is issued for the given client ID.
@@ -292,7 +292,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $response['token_type']);
-        $this->assertSame(3600, $response['expires_in']);
+        $this->assertEqualsWithDelta(3600, $response['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertInstanceOf(RefreshToken::class, $refreshToken);
 
@@ -369,7 +369,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $response['token_type']);
-        $this->assertSame(3600, $response['expires_in']);
+        $this->assertEqualsWithDelta(3600, $response['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertInstanceOf(RefreshToken::class, $refreshToken);
 
@@ -653,7 +653,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
         $accessToken = $this->getAccessToken($response['access_token']);
 
         $this->assertSame('Bearer', $response['token_type']);
-        $this->assertSame(3600, $response['expires_in']);
+        $this->assertEqualsWithDelta(3600, $response['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertSame('foo', $accessToken->getClient()->getIdentifier());
     }
@@ -727,7 +727,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $responseData['token_type']);
-        $this->assertEquals(600, $responseData['expires_in']);
+        $this->assertEqualsWithDelta(600, $responseData['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertSame('foo', $accessToken->getClient()->getIdentifier());
     }
@@ -749,7 +749,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $responseData['token_type']);
-        $this->assertEquals(600, $responseData['expires_in']);
+        $this->assertEqualsWithDelta(600, $responseData['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertSame('foo', $accessToken->getClient()->getIdentifier());
         $this->assertSame('quzbaz', $responseData['state']);
@@ -772,7 +772,7 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
 
         // Response assertions.
         $this->assertSame('Bearer', $responseData['token_type']);
-        $this->assertEquals(600, $responseData['expires_in']);
+        $this->assertEqualsWithDelta(600, $responseData['expires_in'], 2);
         $this->assertInstanceOf(AccessToken::class, $accessToken);
         $this->assertSame('foo', $accessToken->getClient()->getIdentifier());
     }

--- a/Tests/Integration/AuthorizationServerTest.php
+++ b/Tests/Integration/AuthorizationServerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Integration;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use Trikoder\Bundle\OAuth2Bundle\Event\UserResolveEvent;
 use Trikoder\Bundle\OAuth2Bundle\Model\AccessToken;
 use Trikoder\Bundle\OAuth2Bundle\Model\RefreshToken;
@@ -168,12 +168,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'grant_type' => 'client_credentials',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleTokenRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $accessToken = $this->getAccessToken($response['access_token']);
@@ -194,12 +194,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'scope' => 'fancy',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleTokenRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $accessToken = $this->getAccessToken($response['access_token']);
@@ -227,12 +227,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'grant_type' => 'client_credentials',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleTokenRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $accessToken = $this->getAccessToken($response['access_token']);
@@ -261,12 +261,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'scope' => 'rock',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleTokenRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $accessToken = $this->getAccessToken($response['access_token']);
@@ -300,12 +300,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'password' => 'pass',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleTokenRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $accessToken = $this->getAccessToken($response['access_token']);
@@ -383,12 +383,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'refresh_token' => TestHelper::generateEncryptedPayload($existingRefreshToken),
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleTokenRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $accessToken = $this->getAccessToken($response['access_token']);
@@ -675,12 +675,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleTokenRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $accessToken = $this->getAccessToken($response['access_token']);
@@ -751,12 +751,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'client_id' => 'foo',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleAuthorizationRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $this->assertSame(302, $response->getStatusCode());
@@ -779,12 +779,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'state' => 'quzbaz',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleAuthorizationRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $this->assertSame(302, $response->getStatusCode());
@@ -808,12 +808,12 @@ final class AuthorizationServerTest extends AbstractIntegrationTest
             'redirect_uri' => 'https://example.org/oauth2/redirect-uri',
         ]);
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $response = $this->handleAuthorizationRequest($request);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
 
         $this->assertSame(302, $response->getStatusCode());

--- a/Tests/Unit/InMemoryAccessTokenManagerTest.php
+++ b/Tests/Unit/InMemoryAccessTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Unit;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AccessTokenManager as InMemoryAccessTokenManager;
@@ -17,7 +17,7 @@ final class InMemoryAccessTokenManagerTest extends TestCase
     {
         $inMemoryAccessTokenManager = new InMemoryAccessTokenManager();
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $testData = $this->buildClearExpiredTestData();
@@ -29,7 +29,7 @@ final class InMemoryAccessTokenManagerTest extends TestCase
             $this->assertSame(3, $inMemoryAccessTokenManager->clearExpired());
             $this->assertManagerContainsExpectedData($testData['output'], $inMemoryAccessTokenManager);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
     }
 
@@ -91,7 +91,7 @@ final class InMemoryAccessTokenManagerTest extends TestCase
     {
         $accessToken = new AccessToken(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             new Client('client', 'secret'),
             null,
             []

--- a/Tests/Unit/InMemoryAccessTokenManagerTest.php
+++ b/Tests/Unit/InMemoryAccessTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Unit;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AccessTokenManager as InMemoryAccessTokenManager;
@@ -17,7 +17,7 @@ final class InMemoryAccessTokenManagerTest extends TestCase
     {
         $inMemoryAccessTokenManager = new InMemoryAccessTokenManager();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         try {
             $testData = $this->buildClearExpiredTestData();
@@ -29,7 +29,7 @@ final class InMemoryAccessTokenManagerTest extends TestCase
             $this->assertSame(3, $inMemoryAccessTokenManager->clearExpired());
             $this->assertManagerContainsExpectedData($testData['output'], $inMemoryAccessTokenManager);
         } finally {
-            Chronos::setTestNow(null);
+            CarbonImmutable::setTestNow(null);
         }
     }
 
@@ -91,7 +91,7 @@ final class InMemoryAccessTokenManagerTest extends TestCase
     {
         $accessToken = new AccessToken(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             new Client('client', 'secret'),
             null,
             []

--- a/Tests/Unit/InMemoryAuthCodeManagerTest.php
+++ b/Tests/Unit/InMemoryAuthCodeManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Unit;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AuthorizationCodeManager as InMemoryAuthCodeManager;
@@ -17,7 +17,7 @@ final class InMemoryAuthCodeManagerTest extends TestCase
     {
         $inMemoryAuthCodeManager = new InMemoryAuthCodeManager();
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $testData = $this->buildClearExpiredTestData();
@@ -29,7 +29,7 @@ final class InMemoryAuthCodeManagerTest extends TestCase
             $this->assertSame(3, $inMemoryAuthCodeManager->clearExpired());
             $this->assertManagerContainsExpectedData($testData['output'], $inMemoryAuthCodeManager);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
     }
 
@@ -91,7 +91,7 @@ final class InMemoryAuthCodeManagerTest extends TestCase
     {
         $authorizationCode = new AuthorizationCode(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             new Client('client', 'secret'),
             null,
             []

--- a/Tests/Unit/InMemoryAuthCodeManagerTest.php
+++ b/Tests/Unit/InMemoryAuthCodeManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Unit;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AuthorizationCodeManager as InMemoryAuthCodeManager;
@@ -17,7 +17,7 @@ final class InMemoryAuthCodeManagerTest extends TestCase
     {
         $inMemoryAuthCodeManager = new InMemoryAuthCodeManager();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         try {
             $testData = $this->buildClearExpiredTestData();
@@ -29,7 +29,7 @@ final class InMemoryAuthCodeManagerTest extends TestCase
             $this->assertSame(3, $inMemoryAuthCodeManager->clearExpired());
             $this->assertManagerContainsExpectedData($testData['output'], $inMemoryAuthCodeManager);
         } finally {
-            Chronos::setTestNow(null);
+            CarbonImmutable::setTestNow(null);
         }
     }
 
@@ -91,7 +91,7 @@ final class InMemoryAuthCodeManagerTest extends TestCase
     {
         $authorizationCode = new AuthorizationCode(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             new Client('client', 'secret'),
             null,
             []

--- a/Tests/Unit/InMemoryRefreshTokenManagerTest.php
+++ b/Tests/Unit/InMemoryRefreshTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Unit;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\RefreshTokenManager as InMemoryRefreshTokenManager;
@@ -18,7 +18,7 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
     {
         $inMemoryRefreshTokenManager = new InMemoryRefreshTokenManager();
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         try {
             $testData = $this->buildClearExpiredTestData();
@@ -30,7 +30,7 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
             $this->assertSame(3, $inMemoryRefreshTokenManager->clearExpired());
             $this->assertManagerContainsExpectedData($testData['output'], $inMemoryRefreshTokenManager);
         } finally {
-            Chronos::setTestNow(null);
+            CarbonImmutable::setTestNow(null);
         }
     }
 
@@ -92,10 +92,10 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
     {
         $refreshToken = new RefreshToken(
             $identifier,
-            new Chronos($modify),
+            new CarbonImmutable($modify),
             new AccessToken(
                 $identifier,
-                new Chronos('+1 day'),
+                new CarbonImmutable('+1 day'),
                 new Client('client', 'secret'),
                 null,
                 []

--- a/Tests/Unit/InMemoryRefreshTokenManagerTest.php
+++ b/Tests/Unit/InMemoryRefreshTokenManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Trikoder\Bundle\OAuth2Bundle\Tests\Unit;
 
-use DateTimeImmutable;
+use Cake\Chronos\Chronos;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\RefreshTokenManager as InMemoryRefreshTokenManager;
@@ -18,7 +18,7 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
     {
         $inMemoryRefreshTokenManager = new InMemoryRefreshTokenManager();
 
-        timecop_freeze(new DateTimeImmutable());
+        Chronos::setTestNow(Chronos::now());
 
         try {
             $testData = $this->buildClearExpiredTestData();
@@ -30,7 +30,7 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
             $this->assertSame(3, $inMemoryRefreshTokenManager->clearExpired());
             $this->assertManagerContainsExpectedData($testData['output'], $inMemoryRefreshTokenManager);
         } finally {
-            timecop_return();
+            Chronos::setTestNow(null);
         }
     }
 
@@ -92,10 +92,10 @@ final class InMemoryRefreshTokenManagerTest extends TestCase
     {
         $refreshToken = new RefreshToken(
             $identifier,
-            new DateTimeImmutable($modify),
+            new Chronos($modify),
             new AccessToken(
                 $identifier,
-                new DateTimeImmutable('+1 day'),
+                new Chronos('+1 day'),
                 new Client('client', 'secret'),
                 null,
                 []

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     "require": {
         "php": ">=7.2",
         "ajgarlag/psr-http-message-bundle": "^1.1",
-        "cakephp/chronos": "^2.1",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.7",
         "league/oauth2-server": "^8.0",
+        "nesbot/carbon": "^2.46",
         "psr/http-factory": "^1.0",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/psr-http-message-bridge": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "symfony/security-bundle": "^4.4|^5.0"
     },
     "require-dev": {
-        "ext-timecop": "*",
         "ext-xdebug": "*",
+        "cakephp/chronos": "^2.1",
         "laminas/laminas-diactoros": "^2.2",
         "nyholm/psr7": "^1.2",
         "phpunit/phpunit": "^8.5|^9.4",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=7.2",
         "ajgarlag/psr-http-message-bundle": "^1.1",
+        "cakephp/chronos": "^2.1",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.7",
         "league/oauth2-server": "^8.0",
@@ -32,7 +33,6 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "cakephp/chronos": "^2.1",
         "laminas/laminas-diactoros": "^2.2",
         "nyholm/psr7": "^1.2",
         "phpunit/phpunit": "^8.5|^9.4",

--- a/dev/bin/php-debug
+++ b/dev/bin/php-debug
@@ -7,5 +7,4 @@ readonly BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 "${BASE_DIR}"/docker-compose run --rm --no-deps \
     -e PHP_IDE_CONFIG=serverName="${PHP_IDE_CONFIG:-oauth}" \
     -e XDEBUG_REMOTE_AUTOSTART=1 \
-    -e TIMECOP_FUNC_OVERRIDE=1 \
     php "$@"

--- a/dev/bin/php-test
+++ b/dev/bin/php-test
@@ -5,5 +5,4 @@ set -e
 readonly BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 
 "${BASE_DIR}"/docker-compose run --rm --no-deps \
-    -e TIMECOP_FUNC_OVERRIDE=1 \
     php "$@"

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -6,11 +6,9 @@ LABEL maintainer="Petar Obradović <petar.obradovic@trikoder.net>"
 ARG COMPOSER_VERSION=1.9.3
 ARG FLEX_VERSION=1.6.2
 ARG PHP_CS_FIXER_VERSION=2.16.2
-ARG TIMECOP_VERSION=1.2.10
 ARG XDEBUG_VERSION=2.9.2
 
 ENV XDEBUG_REMOTE_AUTOSTART 0
-ENV TIMECOP_FUNC_OVERRIDE 0
 
 # This is where we're going to store all of our non-project specific binaries
 RUN mkdir -p /app/bin
@@ -27,10 +25,8 @@ RUN apk add --update --no-cache --virtual .build-deps \
         zip \
     && pecl install \
         xdebug-${XDEBUG_VERSION} \
-        timecop-${TIMECOP_VERSION} \
     && docker-php-ext-enable \
         xdebug \
-        timecop \
     && apk del --purge .build-deps
 
 RUN mv ${PHP_INI_DIR}/php.ini-development ${PHP_INI_DIR}/php.ini
@@ -40,9 +36,6 @@ RUN echo '[xdebug]' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_enable = 1' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_connect_back = 0' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini \
     && echo 'xdebug.remote_host = %XDEBUG_REMOTE_HOST%' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-xdebug.ini
-
-RUN echo '[timecop]' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-timecop.ini \
-    && echo 'timecop.func_override = ${TIMECOP_FUNC_OVERRIDE}' >> ${PHP_INI_DIR}/conf.d/docker-php-ext-timecop.ini
 
 # Utilities needed to run this image
 RUN apk add --update --no-cache \


### PR DESCRIPTION
Change to prepare support for php 8 #248 

I had add a delta for token expiration checking because this is not really the purpose of integration/acceptance test to check that but the purpose of unit test. This is "mandatory" because `league/oauth2-server` use `DateTimeImmutable` object instead of a clock pattern.

I think the delta is the best way to handle that because in production case it can be something that can append so not really a point.