### PR TITLE
ScopeResolveEvent's property $userIdentifier should accept a mixed argument

### DIFF
--- a/Event/ScopeResolveEvent.php
+++ b/Event/ScopeResolveEvent.php
@@ -27,11 +27,11 @@ final class ScopeResolveEvent extends Event
     private $client;
 
     /**
-     * @var string|null
+     * @var mixed|null
      */
     private $userIdentifier;
 
-    public function __construct(array $scopes, Grant $grant, Client $client, ?string $userIdentifier)
+    public function __construct(array $scopes, Grant $grant, Client $client, $userIdentifier)
     {
         $this->scopes = $scopes;
         $this->grant = $grant;
@@ -64,7 +64,7 @@ final class ScopeResolveEvent extends Event
         return $this->client;
     }
 
-    public function getUserIdentifier(): ?string
+    public function getUserIdentifier()
     {
         return $this->userIdentifier;
     }


### PR DESCRIPTION
According to [League's UserEntityInterface](https://github.com/thephpleague/oauth2-server/blob/master/src/Entities/UserEntityInterface.php) the user identifier contains a mixed value. When using an integer for instance, this results in the following exception:
```Argument 4 passed to Trikoder\\Bundle\\OAuth2Bundle\\Event\\ScopeResolveEvent::__construct() must be of the type string or null, int given, called in \/var\/www\/html\/vendor\/trikoder\/oauth2-bundle\/League\/Repository\/ScopeRepository.php on line 83```

This could be prevented by accepting a mixed value as 4th argument to the constructor of ScopeResolveEvent.