### PR TITLE
Add version 6.0 for the symfony/framework-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/orm": "^2.7",
         "league/oauth2-server": "^8.0",
         "psr/http-factory": "^1.0",
-        "symfony/framework-bundle": "^4.4|^5.0",
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
         "symfony/psr-http-message-bridge": "^2.0",
         "symfony/security-bundle": "^4.4|^5.0"
     },


### PR DESCRIPTION
This package is now blocking an upgrade of the Symfony Framework Bundle, add version 6.x to allow upgrading.