### PR TITLE
Fix deprecation notifications since SF 5.1

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,7 +11,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface" />
         </service>
         <service id="trikoder.oauth2.league.repository.client_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ClientRepository">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="League\OAuth2\Server\Repositories\ClientRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ClientRepository" />
 
@@ -21,7 +21,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter" />
         </service>
         <service id="trikoder.oauth2.league.repository.access_token_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AccessTokenRepository">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AccessTokenRepository" />
 
@@ -30,7 +30,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\AccessTokenManagerInterface" />
         </service>
         <service id="trikoder.oauth2.league.repository.refresh_token_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\RefreshTokenRepository" />
 
@@ -41,7 +41,7 @@
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
         </service>
         <service id="trikoder.oauth2.league.repository.scope_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ScopeRepository">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="League\OAuth2\Server\Repositories\ScopeRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\ScopeRepository" />
 
@@ -51,7 +51,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Converter\UserConverter" />
         </service>
         <service id="trikoder.oauth2.league.repository.user_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\UserRepository">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="League\OAuth2\Server\Repositories\UserRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\UserRepository" />
 
@@ -61,7 +61,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter" />
         </service>
         <service id="trikoder.oauth2.league.repository.auth_code_repository" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface" alias="Trikoder\Bundle\OAuth2Bundle\League\Repository\AuthCodeRepository" />
 
@@ -72,12 +72,12 @@
             <argument key="$oauth2TokenFactory" type="service" id="Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory" />
         </service>
         <service id="trikoder.oauth2.security.authentication.provider.oauth2_provider" alias="Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Provider\OAuth2Provider">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Security\EntryPoint\OAuth2EntryPoint" />
         <service id="trikoder.oauth2.security.entry_point.oauth2_entry_point" alias="Trikoder\Bundle\OAuth2Bundle\Security\EntryPoint\OAuth2EntryPoint">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Security\Firewall\OAuth2Listener">
@@ -87,7 +87,7 @@
             <argument key="$oauth2TokenFactory" type="service" id="Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory" />
         </service>
         <service id="trikoder.oauth2.security.firewall.oauth2_listener" alias="Trikoder\Bundle\OAuth2Bundle\Security\Firewall\OAuth2Listener">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\League\AuthorizationServer\GrantConfigurator">
@@ -156,7 +156,7 @@
             <tag name="controller.service_arguments" />
         </service>
         <service id="trikoder.oauth2.controller.authorization_controller" alias="Trikoder\Bundle\OAuth2Bundle\Controller\AuthorizationController">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <!-- Authorization listeners -->
@@ -165,12 +165,12 @@
             <tag name="kernel.event_listener" event="trikoder.oauth2.authorization_request_resolve" method="onAuthorizationRequest" priority="1024" />
         </service>
         <service id="trikoder.oauth2.event_listener.authorization.user" alias="Trikoder\Bundle\OAuth2Bundle\EventListener\AuthorizationRequestUserResolvingListener">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener" />
         <service id="trikoder.oauth2.event_listener.authorization.convert_to_response" alias="Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <!-- Token controller -->
@@ -179,7 +179,7 @@
             <tag name="controller.service_arguments" />
         </service>
         <service id="trikoder.oauth2.controller.token_controller" alias="Trikoder\Bundle\OAuth2Bundle\Controller\TokenController">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <!-- Commands -->
@@ -188,7 +188,7 @@
             <tag name="console.command" />
         </service>
         <service id="trikoder.oauth2.command.create_client_command" alias="Trikoder\Bundle\OAuth2Bundle\Command\CreateClientCommand">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Command\UpdateClientCommand">
@@ -196,7 +196,7 @@
             <tag name="console.command" />
         </service>
         <service id="trikoder.oauth2.command.update_client_command" alias="Trikoder\Bundle\OAuth2Bundle\Command\UpdateClientCommand">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Command\DeleteClientCommand">
@@ -204,7 +204,7 @@
             <tag name="console.command" />
         </service>
         <service id="trikoder.oauth2.command.delete_client_command" alias="Trikoder\Bundle\OAuth2Bundle\Command\DeleteClientCommand">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Command\ListClientsCommand">
@@ -212,7 +212,7 @@
             <tag name="console.command" />
         </service>
         <service id="trikoder.oauth2.command.list_clients_command" alias="Trikoder\Bundle\OAuth2Bundle\Command\ListClientsCommand">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Command\ClearExpiredTokensCommand">
@@ -222,7 +222,7 @@
             <tag name="console.command" />
         </service>
         <service id="trikoder.oauth2.command.clear_expired_tokens_command" alias="Trikoder\Bundle\OAuth2Bundle\Command\ClearExpiredTokensCommand">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Command\ClearRevokedTokensCommand">
@@ -235,13 +235,13 @@
         <!-- Utility services -->
         <service id="Trikoder\Bundle\OAuth2Bundle\Converter\UserConverter" />
         <service id="trikoder.oauth2.converter.user_converter" alias="Trikoder\Bundle\OAuth2Bundle\Converter\UserConverter">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="Trikoder\Bundle\OAuth2Bundle\Converter\UserConverterInterface" alias="Trikoder\Bundle\OAuth2Bundle\Converter\UserConverter" />
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter" />
         <service id="trikoder.oauth2.converter.scope_converter" alias="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
         <service id="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverterInterface" alias="Trikoder\Bundle\OAuth2Bundle\Converter\ScopeConverter" />
 
@@ -250,7 +250,7 @@
             <argument type="service" id="Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface" />
         </service>
         <service id="trikoder.oauth2.event.authorization_request_resolve_event_factory" alias="Trikoder\Bundle\OAuth2Bundle\Event\AuthorizationRequestResolveEventFactory">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory">

--- a/Resources/config/storage/doctrine.xml
+++ b/Resources/config/storage/doctrine.xml
@@ -21,33 +21,33 @@
             <argument key="$entityManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.client_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager">
             <argument key="$entityManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.access_token_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AccessTokenManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\RefreshTokenManager">
             <argument key="$entityManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.refresh_token_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\RefreshTokenManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ScopeManager" />
         <service id="trikoder.oauth2.manager.in_memory.scope_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ScopeManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AuthorizationCodeManager">
             <argument key="$entityManager" />
         </service>
         <service id="trikoder.oauth2.manager.doctrine.authorization_code_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\AuthorizationCodeManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
     </services>
 </container>

--- a/Resources/config/storage/in_memory.xml
+++ b/Resources/config/storage/in_memory.xml
@@ -14,27 +14,27 @@
         <!-- Services -->
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ClientManager" />
         <service id="trikoder.oauth2.manager.in_memory.client_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ClientManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AccessTokenManager" />
         <service id="trikoder.oauth2.manager.in_memory.access_token_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AccessTokenManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\RefreshTokenManager" />
         <service id="trikoder.oauth2.manager.in_memory.refresh_token_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\RefreshTokenManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ScopeManager" />
         <service id="trikoder.oauth2.manager.in_memory.scope_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\ScopeManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
 
         <service id="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AuthorizationCodeManager" />
         <service id="trikoder.oauth2.manager.in_memory.authorization_code_manager" alias="Trikoder\Bundle\OAuth2Bundle\Manager\InMemory\AuthorizationCodeManager">
-            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
+            <deprecated package="trikoder/oauth2-bundle" version="3.2.0">The "%alias_id%" service alias is deprecated and will be removed in v4.</deprecated>
         </service>
     </services>
 </container>


### PR DESCRIPTION
symfony/dependency-injection states deprecated tags in configurations should have the package name and the version the deprecation started.
This PR will fix that issue