### PR TITLE
fixing notice error for php 8.1

### DIFF
--- a/League/Entity/Scope.php
+++ b/League/Entity/Scope.php
@@ -14,7 +14,7 @@ final class Scope implements ScopeEntityInterface
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getIdentifier();
     }


### PR DESCRIPTION
Return type of Trikoder\Bundle\OAuth2Bundle\League\Entity\Scope::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice.