### PR TITLE
Return NullUser on empty userIdentifier in Oauth2Provider

### DIFF
--- a/Security/Authentication/Provider/OAuth2Provider.php
+++ b/Security/Authentication/Provider/OAuth2Provider.php
@@ -14,6 +14,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2Token;
 use Trikoder\Bundle\OAuth2Bundle\Security\Authentication\Token\OAuth2TokenFactory;
+use Trikoder\Bundle\OAuth2Bundle\Security\User\NullUser;
 
 final class OAuth2Provider implements AuthenticationProviderInterface
 {
@@ -87,11 +88,7 @@ final class OAuth2Provider implements AuthenticationProviderInterface
     private function getAuthenticatedUser(string $userIdentifier): ?UserInterface
     {
         if ('' === $userIdentifier) {
-            /*
-             * If the identifier is an empty string, that means that the
-             * access token isn't bound to a user defined in the system.
-             */
-            return null;
+            return new NullUser();
         }
 
         return $this->userProvider->loadUserByUsername($userIdentifier);

--- a/Security/User/NullUser.php
+++ b/Security/User/NullUser.php
@@ -16,9 +16,14 @@ final class NullUser implements UserInterface
         return '';
     }
 
-    public function getPassword(): string
+    public function getUserIdentifier(): string
     {
         return '';
+    }
+
+    public function getPassword(): ?string
+    {
+        return null;
     }
 
     public function getSalt(): ?string


### PR DESCRIPTION
As of symfony 5.4 AuthorizationCheker and Symfony security always expects user to be defined