### PR TITLE
Added simple explaination for custom scopes

### DIFF
--- a/docs/controlling-token-scopes.md
+++ b/docs/controlling-token-scopes.md
@@ -35,7 +35,7 @@ App\EventListener\ScopeResolveListener:
 ```
 
 ## Work with refresh token
-The scopes created in this way will not be recognized by the library.  
+The scopes created in this way will not be recognized by the library when trying to login using the `refresh_token` grant method.  
 In order to append new scopes, you need to override the service `Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface`.  
 Here is an example:
 ```yaml

--- a/docs/controlling-token-scopes.md
+++ b/docs/controlling-token-scopes.md
@@ -33,3 +33,38 @@ App\EventListener\ScopeResolveListener:
     tags:
         - { name: kernel.event_listener, event: trikoder.oauth2.scope_resolve, method: onScopeResolve }
 ```
+
+## Work with refresh token
+The scopes created in this way will not be recognized by the library.  
+In order to append new scopes, you need to override the service `Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface`.  
+Here is an example:
+```yaml
+# services.yaml
+Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface:
+        alias: Path\To\Custom\Manager
+```
+in the manager you can implement the business logic needed to validate the tokens you issued in the scope resolve listener
+```php
+<?php
+
+namespace App\Guards;
+
+
+use Trikoder\Bundle\OAuth2Bundle\Manager\ScopeManagerInterface;
+use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+
+class CustomScopeManager implements ScopeManagerInterface
+{
+
+    public function find(string $identifier): ?Scope
+    {
+        // your logic here, if created return a new scope with the name
+        return null;
+    }
+
+    public function save(Scope $scope): void
+    {
+        // your logic here
+    }
+}
+```


### PR DESCRIPTION
In order to follow the guide of custom scopes, I was forced to implement what I described in the following.  
The pull request contains the guide to replicate this in the file on controlling token scopes